### PR TITLE
Name Resolver (Module Map) Refactor

### DIFF
--- a/samples/Echo/echo_client-messages.adb
+++ b/samples/Echo/echo_client-messages.adb
@@ -8,6 +8,7 @@ with Ada.Text_IO;
 with Ada.Real_Time;
 
 with Echo_Server.API;
+with Name_Resolver;
 
 package body Echo_Client.Messages is
    use Message_Manager;
@@ -29,8 +30,8 @@ package body Echo_Client.Messages is
       -- Send the first message!
      Send_Time := Ada.Real_Time.Clock;
      Outgoing_Message := Echo_Server.API.Ping_Request_Encode
-        (Sender_Domain => Domain_ID,
-         Sender        => ID,
+        (Sender_Domain => Name_Resolver.Echo_Client.Domain_ID,
+         Sender        => Name_Resolver.Echo_Client.Module_ID,
          Request_ID    => Request_Number);
       Route_Message(Outgoing_Message);
    end Initialize;
@@ -68,8 +69,8 @@ package body Echo_Client.Messages is
          -- Send the next message!
          Send_Time := Ada.Real_Time.Clock;
          Outgoing_Message := Echo_Server.API.Ping_Request_Encode
-           (Sender_Domain => Domain_ID,
-            Sender        => ID,
+           (Sender_Domain => Name_Resolver.Echo_Client.Domain_ID,
+            Sender        => Name_Resolver.Echo_Client.Module_ID,
             Request_ID    => Request_Number);
          Route_Message(Outgoing_Message);
       end if;
@@ -120,7 +121,7 @@ package body Echo_Client.Messages is
    begin
       Initialize;
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.Echo_Client.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/samples/Echo/echo_client-messages.adb
+++ b/samples/Echo/echo_client-messages.adb
@@ -30,8 +30,7 @@ package body Echo_Client.Messages is
       -- Send the first message!
      Send_Time := Ada.Real_Time.Clock;
      Outgoing_Message := Echo_Server.API.Ping_Request_Encode
-        (Sender_Domain => Name_Resolver.Echo_Client.Domain_ID,
-         Sender        => Name_Resolver.Echo_Client.Module_ID,
+        (Sender_Address => Name_Resolver.Echo_Client,
          Request_ID    => Request_Number);
       Route_Message(Outgoing_Message);
    end Initialize;
@@ -69,8 +68,7 @@ package body Echo_Client.Messages is
          -- Send the next message!
          Send_Time := Ada.Real_Time.Clock;
          Outgoing_Message := Echo_Server.API.Ping_Request_Encode
-           (Sender_Domain => Name_Resolver.Echo_Client.Domain_ID,
-            Sender        => Name_Resolver.Echo_Client.Module_ID,
+           (Sender_Address => Name_Resolver.Echo_Client,
             Request_ID    => Request_Number);
          Route_Message(Outgoing_Message);
       end if;

--- a/samples/Echo/echo_client.ads
+++ b/samples/Echo/echo_client.ads
@@ -7,5 +7,5 @@
 with Message_Manager;
 
 package Echo_Client is
-   ID : constant Message_Manager.Module_ID_Type := 5;
+
 end Echo_Client;

--- a/samples/Echo/echo_client.ads
+++ b/samples/Echo/echo_client.ads
@@ -4,6 +4,7 @@
 -- AUTHOR : (C) Copyright 2021 by Vermont Technical College
 --
 --------------------------------------------------------------------------------
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package Echo_Client is

--- a/samples/Echo/echo_server-api.adb
+++ b/samples/Echo/echo_server-api.adb
@@ -11,17 +11,14 @@ package body Echo_Server.API is
    use type XDR.XDR_Unsigned;
 
    function Ping_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender        : Module_ID_Type;
+     (Sender_Address : Message_Address;
       Request_ID    : Request_ID_Type;
       Priority      : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : constant Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Sender_Domain,
-           Receiver_Domain => Name_Resolver.Echo_Server.Domain_ID,
-           Sender          => Sender,
-           Receiver        => Name_Resolver.Echo_Server.Module_ID,
+          (Sender_Address => Sender_Address,
+           Receiver_Address => Name_Resolver.Echo_Server,
            Request_ID      => Request_ID,
            Message_ID      => Message_Type'Pos(Ping_Request),
            Priority        => Priority);
@@ -31,18 +28,15 @@ package body Echo_Server.API is
 
 
    function Ping_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
+     (Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Status     : Status_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Name_Resolver.Echo_Server.Domain_ID,
-           Receiver_Domain => Receiver_Domain,
-           Sender          => Name_Resolver.Echo_Server.Module_ID,
-           Receiver        => Receiver,
+          (Sender_Address => Name_Resolver.Echo_Server,
+           Receiver_Address => Receiver_Address,
            Request_ID      => Request_ID,
            Message_ID      => Message_Type'Pos(Ping_Reply),
            Priority        => Priority);

--- a/samples/Echo/echo_server-api.adb
+++ b/samples/Echo/echo_server-api.adb
@@ -19,9 +19,9 @@ package body Echo_Server.API is
       Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Domain   => Sender_Domain,
-           Receiver_Domain => Domain_ID,
+           Receiver_Domain => Name_Resolver.Echo_Server.Domain_ID,
            Sender          => Sender,
-           Receiver        => ID,
+           Receiver        => Name_Resolver.Echo_Server.Module_ID,
            Request_ID      => Request_ID,
            Message_ID      => Message_Type'Pos(Ping_Request),
            Priority        => Priority);
@@ -39,9 +39,9 @@ package body Echo_Server.API is
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Domain_ID,
+          (Sender_Domain   => Name_Resolver.Echo_Server.Domain_ID,
            Receiver_Domain => Receiver_Domain,
-           Sender          => ID,
+           Sender          => Name_Resolver.Echo_Server.Module_ID,
            Receiver        => Receiver,
            Request_ID      => Request_ID,
            Message_ID      => Message_Type'Pos(Ping_Reply),

--- a/samples/Echo/echo_server-api.ads
+++ b/samples/Echo/echo_server-api.ads
@@ -5,6 +5,7 @@
 --
 --------------------------------------------------------------------------------
 with Message_Manager; use Message_Manager;
+with Name_Resolver;
 with System;
 
 package Echo_Server.API is
@@ -32,10 +33,10 @@ package Echo_Server.API is
        Global => null;
 
    function Is_Ping_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Ping_Request));
+     (Message.Receiver = Name_Resolver.Echo_Server.Module_ID and Message.Message_ID = Message_Type'Pos(Ping_Request));
 
    function Is_Ping_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Ping_Reply));
+     (Message.Sender = Name_Resolver.Echo_Server.Module_ID and Message.Message_ID = Message_Type'Pos(Ping_Reply));
 
    procedure Ping_Request_Decode
      (Message : in Message_Record;

--- a/samples/Echo/echo_server-api.ads
+++ b/samples/Echo/echo_server-api.ads
@@ -16,16 +16,14 @@ package Echo_Server.API is
    type Message_Type is (Ping_Request, Ping_Reply);
 
    function Ping_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender        : Module_ID_Type;
+     (Sender_Address : Message_Address;
       Request_ID    : Request_ID_Type;
       Priority      : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null;
 
    function Ping_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
+     (Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Status     : Status_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
@@ -33,10 +31,10 @@ package Echo_Server.API is
        Global => null;
 
    function Is_Ping_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = Name_Resolver.Echo_Server.Module_ID and Message.Message_ID = Message_Type'Pos(Ping_Request));
+     (Message.Receiver_Address = Name_Resolver.Echo_Server and Message.Message_ID = Message_Type'Pos(Ping_Request));
 
    function Is_Ping_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = Name_Resolver.Echo_Server.Module_ID and Message.Message_ID = Message_Type'Pos(Ping_Reply));
+     (Message.Sender_Address = Name_Resolver.Echo_Server and Message.Message_ID = Message_Type'Pos(Ping_Reply));
 
    procedure Ping_Request_Decode
      (Message : in Message_Record;

--- a/samples/Echo/echo_server-messages.adb
+++ b/samples/Echo/echo_server-messages.adb
@@ -4,6 +4,7 @@
 -- AUTHOR : (C) Copyright 2021 by Vermont Technical College
 --------------------------------------------------------------------------------
 with Echo_Server.API;
+with Name_Resolver;
 
 package body Echo_Server.Messages is
    use Message_Manager;
@@ -56,7 +57,7 @@ package body Echo_Server.Messages is
       Incoming_Message : Message_Manager.Message_Record;
    begin
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.Echo_Server.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/samples/Echo/echo_server-messages.adb
+++ b/samples/Echo/echo_server-messages.adb
@@ -26,8 +26,7 @@ package body Echo_Server.Messages is
       if Decode_Status = Message_Manager.Success then
          Outgoing_Message :=
            Echo_Server.API.Ping_Reply_Encode
-             (Receiver_Domain => Message.Sender_Domain,
-              Receiver        => Message.Sender,
+             (Receiver_Address => Message.Sender_Address,
               Request_ID      => Message.Request_ID,
               Status          => Echo_Server.API.Success);  -- Ping is always successful.
          Message_Manager.Route_Message(Outgoing_Message);

--- a/samples/Echo/echo_server.ads
+++ b/samples/Echo/echo_server.ads
@@ -8,5 +8,5 @@
 with Message_Manager;
 
 package Echo_Server is
-   ID : constant Message_Manager.Module_ID_Type := 6;
+   
 end Echo_Server;

--- a/samples/Echo/echo_server.ads
+++ b/samples/Echo/echo_server.ads
@@ -4,7 +4,7 @@
 -- AUTHOR : (C) Copyright 2021 by Vermont Technical College
 --
 --------------------------------------------------------------------------------
-
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package Echo_Server is

--- a/samples/Echo/message_manager.ads
+++ b/samples/Echo/message_manager.ads
@@ -10,6 +10,6 @@ pragma Elaborate_All(CubedOS.Generic_Message_Manager);
 package Message_Manager is
   new CubedOS.Generic_Message_Manager
     (Domain_Number =>  1,
-     Module_Count  =>  6,
+     Module_Count  =>  9,
      Mailbox_Size  =>  8,
-     Maximum_Message_Size => 1024);
+     Maximum_Message_Size => 512);

--- a/samples/Echo/message_manager.ads
+++ b/samples/Echo/message_manager.ads
@@ -10,6 +10,6 @@ pragma Elaborate_All(CubedOS.Generic_Message_Manager);
 package Message_Manager is
   new CubedOS.Generic_Message_Manager
     (Domain_Number =>  1,
-     Module_Count  =>  9,
+     Module_Count  =>  2,
      Mailbox_Size  =>  8,
      Maximum_Message_Size => 512);

--- a/samples/Echo/name_resolver.ads
+++ b/samples/Echo/name_resolver.ads
@@ -1,0 +1,32 @@
+--------------------------------------------------------------------------------
+-- FILE    : name_resolver.ads
+-- SUBJECT : Specification holding Domain IDs and Module IDs
+-- AUTHOR  : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with Message_Manager;
+
+package Name_Resolver is
+
+   type Message_Address is record
+      Domain_ID : MEssage_Manager.Domain_ID_Type;
+      Module_ID : MEssage_Manager.Module_ID_Type;
+   end record;
+
+   -- Core Modules Should have the same Module IDs on each domain
+   -- Where do we define the number of domains?
+
+    -- 1. Name resolver (NOT IMPLEMENTED. Used for dynamic module ID assignments) do we need this?
+    Log_Server               : constant Message_Address := (0, 2);
+    Publish_Subscribe_Server : constant Message_Address := (0, 3);
+    Time_Server              : constant Message_Address := (0,4);
+    Event_Server             : constant Message_Address := (0,5);
+    File_Server              : constant Message_Address := (0,6);
+    Table_Server             : constant Message_Address := (0,7);
+
+    -- Application-Specific Modules
+    -- 5. Echo_Client
+    -- 6. Echo_Server
+    Echo_Client             : constant Message_Address := (0,8);
+    Echo_Server             : constant Message_Address := (0,9);
+end Name_Resolver;

--- a/samples/Echo/name_resolver.ads
+++ b/samples/Echo/name_resolver.ads
@@ -4,19 +4,11 @@
 -- AUTHOR  : (C) Copyright 2021 by Vermont Technical College
 --
 --------------------------------------------------------------------------------
-with Message_Manager;
+with Message_Manager; use Message_Manager;
 
 package Name_Resolver is
 
-   type Message_Address is record
-      Domain_ID : MEssage_Manager.Domain_ID_Type;
-      Module_ID : MEssage_Manager.Module_ID_Type;
-   end record;
-
-   -- Core Modules Should have the same Module IDs on each domain
-   -- Where do we define the number of domains?
-
-    -- 1. Name resolver (NOT IMPLEMENTED. Used for dynamic module ID assignments) do we need this?
+    -- Core Modules
     Log_Server               : constant Message_Address := (0, 2);
     Publish_Subscribe_Server : constant Message_Address := (0, 3);
     Time_Server              : constant Message_Address := (0,4);
@@ -25,8 +17,7 @@ package Name_Resolver is
     Table_Server             : constant Message_Address := (0,7);
 
     -- Application-Specific Modules
-    -- 5. Echo_Client
-    -- 6. Echo_Server
     Echo_Client             : constant Message_Address := (0,8);
     Echo_Server             : constant Message_Address := (0,9);
+    
 end Name_Resolver;

--- a/samples/Echo/name_resolver.ads
+++ b/samples/Echo/name_resolver.ads
@@ -9,15 +9,16 @@ with Message_Manager; use Message_Manager;
 package Name_Resolver is
 
     -- Core Modules
-    Log_Server               : constant Message_Address := (0, 2);
-    Publish_Subscribe_Server : constant Message_Address := (0, 3);
-    Time_Server              : constant Message_Address := (0,4);
-    Event_Server             : constant Message_Address := (0,5);
-    File_Server              : constant Message_Address := (0,6);
-    Table_Server             : constant Message_Address := (0,7);
+    -- Log_Server               : constant Message_Address := (0, 2);
+    -- Publish_Subscribe_Server : constant Message_Address := (0, 3);
+    -- Time_Server              : constant Message_Address := (0,4);
+    -- Event_Server             : constant Message_Address := (0,5);
+    -- File_Server              : constant Message_Address := (0,6);
+    -- Table_Server             : constant Message_Address := (0,7);
+    -- Interpreter              : constant Message_Address := (0,10);
 
     -- Application-Specific Modules
-    Echo_Client             : constant Message_Address := (0,8);
-    Echo_Server             : constant Message_Address := (0,9);
-    
+    Echo_Client             : constant Message_Address := (0,1);
+    Echo_Server             : constant Message_Address := (0,2);
+
 end Name_Resolver;

--- a/samples/STM32F4/button_driver-messages.adb
+++ b/samples/STM32F4/button_driver-messages.adb
@@ -9,6 +9,7 @@
 pragma SPARK_Mode(On);
 
 with Button; use Button;
+with Name_Resolver;
 --with LEDs; -- Used for testing
 with CubedOS.Lib; use CubedOS.Lib;
 with CubedOS.Publish_Subscribe_Server.API; use CubedOS.Publish_Subscribe_Server.API;
@@ -27,8 +28,7 @@ package body Button_Driver.Messages is
 
        -- Craft a publish request message
        Outgoing_Message := Publish_Request_Encode
-        (Sender_Domain => Domain_ID,
-         Sender        => Button_Driver.ID,
+        (Sender_Address => Name_Resolver.Button_Driver,
          Request_ID    => 0,
          Channel       => 1,
          Message_Data  => Message_Data,

--- a/samples/STM32F4/button_driver.ads
+++ b/samples/STM32F4/button_driver.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package Button_Driver is

--- a/samples/STM32F4/button_driver.ads
+++ b/samples/STM32F4/button_driver.ads
@@ -10,6 +10,4 @@ with Message_Manager;
 
 package Button_Driver is
 
-   ID : constant Message_Manager.Module_ID_Type := 6;
-
 end Button_Driver;

--- a/samples/STM32F4/control-messages.adb
+++ b/samples/STM32F4/control-messages.adb
@@ -11,6 +11,7 @@ with CubedOS.Time_Server.API;
 use  CubedOS;
 with LED_Driver.API;
 with LED_Driver; use LED_Driver;
+with Name_Resolver;
 --with LEDs; -- Used for testing
 with CubedOS.Publish_Subscribe_Server.API; use CubedOS.Publish_Subscribe_Server.API;
 
@@ -40,16 +41,14 @@ package body Control.Messages is
      -- Cancel the tick request, set tick timer to 10.0 seconds
      if (Counter mod 3 = 0) then
       Outgoing_Message := Time_Server.API.Cancel_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Series_ID     => 1,
          Priority      => System.Default_Priority);
       Route_Message(Outgoing_Message);
 
       Outgoing_Message := Time_Server.API.Relative_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Tick_Interval => Ada.Real_Time.To_Time_Span(10.0),
          Request_Type  => Time_Server.API.Periodic,
@@ -60,16 +59,14 @@ package body Control.Messages is
    -- Cancel the tick request, set tick timer to 3.0 seconds
      elsif (Counter mod 3 = 1) then
       Outgoing_Message := Time_Server.API.Cancel_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Series_ID     => 1,
          Priority      => System.Default_Priority);
       Route_Message(Outgoing_Message);
 
       Outgoing_Message := Time_Server.API.Relative_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Tick_Interval => Ada.Real_Time.To_Time_Span(3.0),
          Request_Type  => Time_Server.API.Periodic,
@@ -80,16 +77,14 @@ package body Control.Messages is
      -- Cancel the tick request, set tick timer to 1.0 seconds
      elsif (Counter mod 3 = 2) then
       Outgoing_Message := Time_Server.API.Cancel_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Series_ID     => 1,
          Priority      => System.Default_Priority);
       Route_Message(Outgoing_Message);
 
       Outgoing_Message := Time_Server.API.Relative_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Tick_Interval => Ada.Real_Time.To_Time_Span(1.0),
          Request_Type  => Time_Server.API.Periodic,
@@ -108,8 +103,7 @@ package body Control.Messages is
       Outgoing_Message : Message_Record;
    begin
       Outgoing_Message := LED_Driver.API.Off_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          LED           => Pattern(Current_LED));
       Route_Message(Outgoing_Message);
@@ -117,8 +111,7 @@ package body Control.Messages is
       Current_LED := Current_LED + 1;
 
       Outgoing_Message := LED_Driver.API.On_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          LED           => Pattern(Current_LED));
       Route_Message(Outgoing_Message);
@@ -160,23 +153,20 @@ package body Control.Messages is
 
       -- Make sure all the LEDs are off.
       Outgoing_Message := LED_Driver.API.All_Off_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0);
       Route_Message(Outgoing_Message);
 
       -- Turn blue LED on for init state
       Outgoing_Message := LED_Driver.API.On_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          LED           => LED_Driver.Blue);
       Route_Message(Outgoing_Message);
 
       -- Request a periodic tick every 10.0 seconds.
       Outgoing_Message := Time_Server.API.Relative_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Tick_Interval => Ada.Real_Time.To_Time_Span(10.0),
          Request_Type  => Time_Server.API.Periodic,
@@ -185,8 +175,7 @@ package body Control.Messages is
 
          -- Subscribe to channel 1.
       Outgoing_Message := Subscribe_Request_Encode
-        (Sender_Domain => 1,
-         Sender        => Control.ID,
+        (Sender_Address => Name_Resolver.Control,
          Request_ID    => 0,
          Channel       => 1,
          Priority      => System.Default_Priority);
@@ -194,7 +183,7 @@ package body Control.Messages is
 
 
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.Control.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/samples/STM32F4/control.ads
+++ b/samples/STM32F4/control.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package Control is

--- a/samples/STM32F4/control.ads
+++ b/samples/STM32F4/control.ads
@@ -10,6 +10,4 @@ with Message_Manager;
 
 package Control is
 
-   ID : constant Message_Manager.Module_ID_Type := 7;
-
 end Control;

--- a/samples/STM32F4/led_driver-api.adb
+++ b/samples/STM32F4/led_driver-api.adb
@@ -15,15 +15,14 @@ package body LED_Driver.API is
    pragma Warnings (Off, "*may call Last_Chance_Handler");
 
    function On_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      LED        : LED_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      LED            : LED_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(On_Request), Priority);
+          (Sender_Address, Name_Resolver.LED_Driver, Request_ID, Message_Type'Pos(On_Request), Priority);
       Position : Data_Index_Type;
       Last     : Data_Index_Type;
    begin
@@ -37,15 +36,14 @@ package body LED_Driver.API is
 
 
    function Off_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      LED        : LED_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      LED            : LED_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(Off_Request), Priority);
+          (Sender_Address, Name_Resolver.LED_Driver, Request_ID, Message_Type'Pos(Off_Request), Priority);
       Position : Data_Index_Type;
       Last     : Data_Index_Type;
    begin
@@ -59,14 +57,13 @@ package body LED_Driver.API is
 
 
    function All_On_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(All_On_Request), Priority);
+          (Sender_Address, Name_Resolver.LED_Driver, Request_ID, Message_Type'Pos(All_On_Request), Priority);
    begin
       Message.Size := 0;
       return Message;
@@ -74,14 +71,13 @@ package body LED_Driver.API is
 
 
    function All_Off_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(All_Off_Request), Priority);
+          (Sender_Address, Name_Resolver.LED_Driver, Request_ID, Message_Type'Pos(All_Off_Request), Priority);
    begin
       Message.Size := 0;
       return Message;

--- a/samples/STM32F4/led_driver-api.ads
+++ b/samples/STM32F4/led_driver-api.ads
@@ -7,6 +7,7 @@
 pragma SPARK_Mode(On);
 
 with Message_Manager;  use Message_Manager;
+with Name_Resolver;
 with System;
 
 package LED_Driver.API is
@@ -15,47 +16,43 @@ package LED_Driver.API is
 
 
    function On_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      LED        : LED_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      LED            : LED_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Off_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      LED        : LED_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      LED            : LED_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function All_On_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function All_Off_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
 
    function Is_On_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(On_Request));
+     (Message.Receiver_Address = Name_Resolver.LED_Driver and Message.Message_ID = Message_Type'Pos(On_Request));
 
    function Is_Off_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Off_Request));
+     (Message.Receiver_Address = Name_Resolver.LED_Driver and Message.Message_ID = Message_Type'Pos(Off_Request));
 
    function Is_All_On_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(All_On_Request));
+     (Message.Receiver_Address = Name_Resolver.LED_Driver and Message.Message_ID = Message_Type'Pos(All_On_Request));
 
    function Is_All_Off_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(All_Off_Request));
+     (Message.Receiver_Address = Name_Resolver.LED_Driver and Message.Message_ID = Message_Type'Pos(All_Off_Request));
 
 
    procedure On_Request_Decode

--- a/samples/STM32F4/led_driver-messages.adb
+++ b/samples/STM32F4/led_driver-messages.adb
@@ -8,6 +8,7 @@ pragma SPARK_Mode(On);
 
 with LEDs;
 with LED_Driver.API;
+with Name_Resolver;
 
 package body LED_Driver.Messages is
    use Message_Manager;
@@ -98,7 +99,7 @@ package body LED_Driver.Messages is
       Incoming_Message : Message_Manager.Message_Record;
    begin
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.LED_Driver.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/samples/STM32F4/led_driver.ads
+++ b/samples/STM32F4/led_driver.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package LED_Driver is

--- a/samples/STM32F4/led_driver.ads
+++ b/samples/STM32F4/led_driver.ads
@@ -10,8 +10,6 @@ with Message_Manager;
 
 package LED_Driver is
 
-   ID : constant Message_Manager.Module_ID_Type := 5;
-
    type LED_Type is (Green, Orange, Red, Blue);
 
 end LED_Driver;

--- a/samples/STM32F4/message_manager.ads
+++ b/samples/STM32F4/message_manager.ads
@@ -10,6 +10,6 @@ with CubedOS.Generic_Message_Manager;
 package Message_Manager is
   new CubedOS.Generic_Message_Manager
     (Domain_Number => 1,
-     Module_Count  => 8,
+     Module_Count  => 5,
      Mailbox_Size  => 4,
      Maximum_Message_Size => 32);

--- a/samples/STM32F4/name_resolver.ads
+++ b/samples/STM32F4/name_resolver.ads
@@ -1,0 +1,25 @@
+--------------------------------------------------------------------------------
+-- FILE    : name_resolver.ads
+-- SUBJECT : Specification holding Domain IDs and Module IDs
+-- AUTHOR  : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with Message_Manager; use Message_Manager;
+
+package Name_Resolver is
+
+    -- Core Modules
+    -- Log_Server               : constant Message_Address := (0, 2);
+    Publish_Subscribe_Server : constant Message_Address := (0, 1);
+    Time_Server              : constant Message_Address := (0,2);
+    -- Event_Server             : constant Message_Address := (0,5);
+    -- File_Server              : constant Message_Address := (0,6);
+    -- Table_Server             : constant Message_Address := (0,7);
+    -- Interpreter              : constant Message_Address := (0,10);
+
+    -- Application-Specific Modules
+    LED_Driver               : constant Message_Address := (0,3);
+    Button_Driver            : constant Message_Address := (0, 4);
+    Control                  : constant Message_Address := (0,5);
+
+end Name_Resolver;

--- a/src/check/main_file.adb
+++ b/src/check/main_file.adb
@@ -40,19 +40,19 @@ begin
 
    -- Try to open a file to read.
    Message_Manager.Route_Message
-     (Open_Request_Encode(Domain_ID, My_Module_ID, 1, Read, "example.txt"));
+     (Open_Request_Encode((Domain_ID, My_Module_ID), 1, Read, "example.txt"));
    Put_Line("TX : Open_Request message sent for reading 'example.txt'");
 
    -- Try to open file for writing
    Message_Manager.Route_Message
-     (Open_Request_Encode(Domain_ID, My_Module_ID, 2, Write, "write_test.txt"));
+     (Open_Request_Encode((Domain_ID, My_Module_ID), 2, Write, "write_test.txt"));
    Put_Line("TX : Open_Request message sent for writing 'write_test.txt'");
 
    loop
       Message_Manager.Fetch_Message(My_Module_ID, Incoming_Message);
       Put_Line("+++ Fetch returned!");
-      Put("+++    Sender    : "); Put(Incoming_Message.Sender); New_Line;
-      Put("+++    Receiver  : "); Put(Incoming_Message.Receiver); New_Line;
+      Put("+++    Sender    : "); Put(Incoming_Message.Sender_Address.Module_ID); New_Line;
+      Put("+++    Receiver  : "); Put(Incoming_Message.Receiver_Address.Module_ID); New_Line;
       Put("+++    Message_ID: "); Put(Integer(Incoming_Message.Message_ID)); New_Line(2);
 
       -- Process open reply messages.
@@ -74,7 +74,7 @@ begin
                   -- We got a reply to our open-for-reading request.
                   Read_Handle := Handle;
                   Message_Manager.Route_Message
-                    (Read_Request_Encode(Domain_ID, My_Module_ID, 0, Read_Handle, Maximum_Read_Size));
+                    (Read_Request_Encode((Domain_ID, My_Module_ID), 0, Read_Handle, Maximum_Read_Size));
                   Put_Line("TX : Read_Request message sent requesting " & Integer'Image(Maximum_Read_Size) & " octets");
 
                when 2 =>
@@ -95,7 +95,7 @@ begin
          if Status = Malformed then
             Put_Line("     *** Message is malformed!");
 	    Message_Manager.Route_Message
-	      (Close_Request_Encode(Domain_ID, My_Module_ID, 0, Read_Handle));
+	      (Close_Request_Encode((Domain_ID, My_Module_ID), 0, Read_Handle));
 	    Put_Line("TX : Close_Request message sent (input file)");
          else
             Put_Line("     +++ Successfully read " & Read_Size_Type'Image(Amount_Read) & " octets");
@@ -103,11 +103,11 @@ begin
             if Amount_Read = 0 then
                -- Close the files (both of them).
                Message_Manager.Route_Message
-                 (Close_Request_Encode(Domain_ID, My_Module_ID, 0, Read_Handle));
+                 (Close_Request_Encode((Domain_ID, My_Module_ID), 0, Read_Handle));
                Put_Line("TX : Close_Request message sent (input file)");
 
                Message_Manager.Route_Message
-                 (Close_Request_Encode(Domain_ID, My_Module_ID, 0, Write_Handle));
+                 (Close_Request_Encode((Domain_ID, My_Module_ID), 0, Write_Handle));
                Put_Line("TX : Close_Request message sent (output file)");
             else
                -- Print the data we just read (it's a text file).
@@ -119,12 +119,12 @@ begin
                -- Write this data to the output file too.
                Amount_Write := Amount_Read;
                Message_Manager.Route_Message
-                 (Write_Request_Encode(Domain_ID, My_Module_ID, 0, Write_Handle, Amount_Write, Data));
+                 (Write_Request_Encode((Domain_ID, My_Module_ID), 0, Write_Handle, Amount_Write, Data));
                Put_Line("TX : Write_Request message sent writing " & Integer'Image(Amount_Write) & " octets");
 
                -- Request the next chunk from the file.
                Message_Manager.Route_Message
-                 (Read_Request_Encode(Domain_ID, My_Module_ID, 0, Read_Handle, Maximum_Read_Size));
+                 (Read_Request_Encode((Domain_ID, My_Module_ID), 0, Read_Handle, Maximum_Read_Size));
                Put_Line("TX : Read_Request message sent requesting " & Integer'Image(Maximum_Read_Size) & " octets");
             end if;
          end if;
@@ -136,7 +136,7 @@ begin
 	 if Status = Malformed then
 	    Put_Line("     *** Message is malformed!");
 	    Message_Manager.Route_Message
-	      (Close_Request_Encode(Domain_ID, My_Module_ID, 0, Write_Handle));
+	      (Close_Request_Encode((Domain_ID, My_Module_ID), 0, Write_Handle));
 	    Put_Line("TX : Close_Request message sent (output file)");
 	 else
 	    Put_Line("     +++ Successfully wrote " & Write_Result_Size_Type'Image(Amount_Write) & " octets");

--- a/src/check/main_message_manager.adb
+++ b/src/check/main_message_manager.adb
@@ -18,11 +18,11 @@ procedure Main_Message_Manager is
       Put_Line("+++++ FETCHING MESSAGES FOR RECIEVER ID = 1 +++++");
       New_Line;
       while Y < 9 loop
-      Fetch_Message(Module  => Message.Receiver, Message => Message);
+      Fetch_Message(Module  => Message.Receiver_Address.Module_ID, Message => Message);
       Put_Line("Message " & Integer'Image(Y) & " fetched ");
-      Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message.Sender));
-      Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message.Receiver));
-      Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message.Message_ID));
+      Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message.Sender_Address.Module_ID));
+      Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message.Receiver_Address.Module_ID));
+      Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message.Message_ID));
       Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message.Request_ID));
       New_Line;
 
@@ -38,11 +38,11 @@ procedure Main_Message_Manager is
       Put_Line("+++++ FETCHING MESSAGES FOR RECIEVER ID = 2 +++++");
       New_Line;
       while Y < 9 loop
-      Fetch_Message(Module  => Message_5.Receiver, Message => Message_5);
+      Fetch_Message(Module  => Message_5.Receiver_Address.Module_ID, Message => Message_5);
       Put_Line("Message " & Integer'Image(Y) & " fetched ");
-      Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_5.Sender));
-      Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver));
-      Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message_5.Message_ID));
+      Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_5.Sender_Address.Module_ID));
+      Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver_Address.Module_ID));
+      Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message_5.Message_ID));
       Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message_5.Request_ID));
       New_Line;
 
@@ -63,7 +63,7 @@ begin
    Get_Next_Request_ID(Request_ID => Message_5.Request_ID);
    Get_Next_Request_ID(Request_ID => Message_6.Request_ID);
    New_Line;
-   Put_Line("Message -- Request ID: " & Request_ID_Type'Image (Message.Request_ID));
+   Put_Line("Message   -- Request ID: " & Request_ID_Type'Image (Message.Request_ID));
    Put_Line("Message_2 -- Request ID: " & Request_ID_Type'Image (Message_2.Request_ID));
    Put_Line("Message_3 -- Request ID: " & Request_ID_Type'Image (Message_3.Request_ID));
    Put_Line("Message_4 -- Request ID: " & Request_ID_Type'Image (Message_4.Request_ID));
@@ -72,40 +72,29 @@ begin
    New_Line;New_Line;
 
    -- Test Make_Empty_Message
-   Message_3 := Make_Empty_Message(Sender_Domain   => 0,
-                                   Receiver_Domain => 0,
-                                   Sender          => 2,
-                                   Receiver        => 1,
-                                   Request_ID      => 4,
-                                   Message_ID      => Message_ID,
-                                   Priority        => 2);
+   Message_3 := Make_Empty_Message(Sender_Address   => (0, 2),
+                                   Receiver_Address => (0, 1),
+                                   Request_ID       => 4,
+                                   Message_ID       => Message_ID,
+                                   Priority         => 2);
 
-   Message_4 := Make_Empty_Message(Sender_Domain   => 1,
-                                   Receiver_Domain => 1,
-                                   Sender          => 1,
-                                   Receiver        => 2,
-                                   Request_ID      => 8,
-                                   Message_ID      => Message_ID_2,
-                                   Priority        => 5);
+   Message_4 := Make_Empty_Message(Sender_Address   => (1, 1),
+                                   Receiver_Address => (1, 2),
+                                   Request_ID       => 8,
+                                   Message_ID       => Message_ID_2,
+                                   Priority         => 5);
 
+   Message_5 := Make_Empty_Message(Sender_Address   => (2, 2),
+                                   Receiver_Address => (1, 2),
+                                   Request_ID       => 1,
+                                   Message_ID       => 1,
+                                   Priority         => 1);
 
-   Message_5 := Make_Empty_Message(Sender_Domain   => 2,
-                                   Receiver_Domain => 1,
-                                   Sender          => 2,
-                                   Receiver        => 2,
-                                   Request_ID      => 1,
-                                   Message_ID      => 1,
-                                   Priority        => 1);
-
-   Message_6 := Make_Empty_Message(Sender_Domain   => 1,
-                                   Receiver_Domain => 1,
-                                   Sender          => 2,
-                                   Receiver        => 2,
-                                   Request_ID      => 1,
-                                   Message_ID      => Message_ID_2,
-                                   Priority        => 4);
-
-
+   Message_6 := Make_Empty_Message(Sender_Address   => (1, 2),
+                                   Receiver_Address => (1, 2),
+                                   Request_ID       => 1,
+                                   Message_ID       => Message_ID_2,
+                                   Priority         => 4);
 
 
    -- 20 messages should be attempted to be sent, only first eight should be sent
@@ -116,9 +105,9 @@ begin
            Route_Message(Message => Message_3, Status => Message_Status);
            Put("Message" & Integer'Image(X) & " routed");
            Put(" +++   Status : " & Status_Type'Image(Message_Status));New_Line;
-           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_3.Sender));
-           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_3.Receiver));
-           Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message_3.Message_ID));
+           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_3.Sender_Address.Module_ID));
+           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_3.Receiver_Address.Module_ID));
+           Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message_3.Message_ID));
            Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message_3.Request_ID));
          New_Line;
          X := X + 1;
@@ -128,9 +117,9 @@ begin
                        Status  => Message_Status);
          Put("Message" & Integer'Image(X) & " routed");
            Put(" +++   Status : " & Status_Type'Image(Message_Status));New_Line;
-           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_4.Sender));
-           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_4.Receiver));
-           Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message_4.Message_ID));
+           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_4.Sender_Address.Module_ID));
+           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_4.Receiver_Address.Module_ID));
+           Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message_4.Message_ID));
            Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message_4.Request_ID));
          New_Line;
          X := X + 1;
@@ -140,9 +129,9 @@ begin
                        Status  => Message_Status);
           Put("Message" & Integer'Image(X) & " routed");
            Put(" +++   Status : " & Status_Type'Image(Message_Status));New_Line;
-           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_5.Sender));
-           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver));
-           Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message_5.Message_ID));
+           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_5.Sender_Address.Module_ID));
+           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver_Address.Module_ID));
+           Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message_5.Message_ID));
            Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message_5.Request_ID));
          New_Line;
          X := X + 1;
@@ -153,9 +142,9 @@ begin
            Route_Message(Message => Message_2);
            Put("Message" & Integer'Image(X) & " routed");
            Put(" +++   Status : " & Status_Type'Image(Message_Status));New_Line;
-           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_2.Sender));
-           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_2.Receiver));
-           Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message_2.Message_ID));
+           Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_2.Sender_Address.Module_ID));
+           Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_2.Receiver_Address.Module_ID));
+           Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message_2.Message_ID));
            Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message_2.Request_ID));
          New_Line;
          X := X + 1;
@@ -166,9 +155,9 @@ begin
          Route_Message(Message => Message, Status => Message_Status);
           Put("Message" & Integer'Image(X) & " routed");
           Put(" +++   Status : " & Status_Type'Image(Message_Status));New_Line;
-          Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message.Sender));
-          Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message.Receiver));
-          Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message.Message_ID));
+          Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message.Sender_Address.Module_ID));
+          Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message.Receiver_Address.Module_ID));
+          Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message.Message_ID));
           Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message.Request_ID));
          New_Line;
          X := X + 1;
@@ -178,9 +167,9 @@ begin
          Route_Message(Message => Message_6, Status => Message_Status);
           Put("Message" & Integer'Image(X) & " routed");
           Put(" +++   Status : " & Status_Type'Image(Message_Status));New_Line;
-          Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_6.Sender));
-          Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_6.Receiver));
-          Put_Line("+++   Message ID  : " & Message_ID_Type'Image (Message_6.Message_ID));
+          Put_Line("+++   Sender ID   : " & Module_ID_Type'Image (Message_6.Sender_Address.Module_ID));
+          Put_Line("+++   Reciever ID : " & Module_ID_Type'Image (Message_6.Receiver_Address.Module_ID));
+          Put_Line("+++   Message ID  : " & Message_ID_Type'Image(Message_6.Message_ID));
           Put_Line("+++   Request ID  : " & Request_ID_Type'Image(Message_6.Request_ID));
          New_Line;
             X := X + 1;

--- a/src/check/main_time.adb
+++ b/src/check/main_time.adb
@@ -48,11 +48,11 @@ begin
 
    -- Do some setup...
    Message_Manager.Route_Message
-     (Relative_Request_Encode(Domain_ID, My_Module_ID, 1, Ada.Real_Time.Milliseconds(3000), Periodic, 1));
+     (Relative_Request_Encode((Domain_ID, My_Module_ID), 1, Ada.Real_Time.Milliseconds(3000), Periodic, 1));
    Put_Line("TX : Relative_Request message sent for 3 second periodic ticks; Series_ID = 1");
 
    Message_Manager.Route_Message
-     (Relative_Request_Encode(Domain_ID, My_Module_ID, 1, Ada.Real_Time.Milliseconds(10000), One_Shot, 2));
+     (Relative_Request_Encode((Domain_ID, My_Module_ID), 1, Ada.Real_Time.Milliseconds(10000), One_Shot, 2));
    Put_Line("TX : Relative_Request message sent for 10 second one shot; Series_ID = 2");
 
    loop
@@ -74,7 +74,7 @@ begin
             -- Cancel series #1 after 10 ticks.
             if Series_ID = 1 and then Count = 10 then
                Message_Manager.Route_Message
-                 (Cancel_Request_Encode(Domain_ID, My_Module_ID, 1, Series_ID => 1));
+                 (Cancel_Request_Encode((Domain_ID, My_Module_ID), 1, Series_ID => 1));
                Put_Line("TX : Cancel_Request message sent for Series_ID = 1");
             end if;
 

--- a/src/modules/cubedos-file_server-api.adb
+++ b/src/modules/cubedos-file_server-api.adb
@@ -17,18 +17,15 @@ package body CubedOS.File_Server.API is
 
    -- Requester-side Use
    function Open_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Mode       : Mode_Type;
-      Name       : String;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Mode           : Mode_Type;
+      Name           : String;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address => Sender_Address,
+         Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Open_Request),
          Priority   => Priority);
@@ -49,17 +46,14 @@ package body CubedOS.File_Server.API is
 
    -- Server-side Use
    function Open_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : API.File_Handle_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Handle           : API.File_Handle_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Domain_ID,
-         Receiver_Domain => Receiver_Domain,
-         Sender     => ID,
-         Receiver   => Receiver,
+        (Sender_Address => Name_Resolver.File_Server,
+         Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(API.Open_Reply),
          Priority   => Priority);
@@ -75,18 +69,15 @@ package body CubedOS.File_Server.API is
 
 
    function Read_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Read_Size_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Handle         : Valid_File_Handle_Type;
+      Amount         : Read_Size_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address => Sender_Address,
+         Receiver_Address => Name_Resolver.File_Server, 
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Read_Request),
          Priority   => Priority);
@@ -105,19 +96,16 @@ package body CubedOS.File_Server.API is
 
    -- Server-side use.
    function Read_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Read_Result_Size_Type;
-      Data       : Octet_Array;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Handle           : Valid_File_Handle_Type;
+      Amount           : Read_Result_Size_Type;
+      Data             : Octet_Array;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Domain_ID,
-         Receiver_Domain => Receiver_Domain,
-         Sender     => ID,
-         Receiver   => Receiver,
+        (Sender_Address => Name_Resolver.File_Server,
+         Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(API.Read_Reply),
          Priority   => Priority);
@@ -137,19 +125,16 @@ package body CubedOS.File_Server.API is
 
 
    function Write_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Write_Size_Type;
-      Data       : Octet_Array;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Handle         : Valid_File_Handle_Type;
+      Amount         : Write_Size_Type;
+      Data           : Octet_Array;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address => Sender_Address,
+         Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Write_Request),
          Priority   => Priority);
@@ -170,18 +155,15 @@ package body CubedOS.File_Server.API is
 
    -- Server-side use.
    function Write_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Write_Result_Size_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Handle           : Valid_File_Handle_Type;
+      Amount           : Write_Result_Size_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Domain_ID,
-         Receiver_Domain => Receiver_Domain,
-         Sender     => ID,
-         Receiver   => Receiver,
+        (Sender_Address => Name_Resolver.File_Server,
+         Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(API.Write_Reply),
          Priority   => Priority);
@@ -199,17 +181,14 @@ package body CubedOS.File_Server.API is
 
 
    function Close_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Handle         : Valid_File_Handle_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record := Make_Empty_Message
-        (Sender_Domain => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address => Sender_Address,
+         Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Close_Request),
          Priority   => Priority);

--- a/src/modules/cubedos-file_server-api.ads
+++ b/src/modules/cubedos-file_server-api.ads
@@ -12,7 +12,7 @@ pragma SPARK_Mode(On);
 with CubedOS.Lib;
 with Message_Manager;
 with System;
-
+with Name_Resolver;
 use Message_Manager;
 
 package CubedOS.File_Server.API is
@@ -44,97 +44,90 @@ package CubedOS.File_Server.API is
    subtype Write_Size_Type is Natural range 1 .. Write_Result_Size_Type'Last;
 
    function Open_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Mode       : Mode_Type;
-      Name       : String;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Mode           : Mode_Type;
+      Name           : String;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Pre => (0 < Name'Length and Name'Length <= Data_Size_Type'Last - 12);
 
    function Open_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : File_Handle_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Handle           : File_Handle_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null;
 
    function Read_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Read_Size_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Handle         : Valid_File_Handle_Type;
+      Amount         : Read_Size_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Read_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Read_Result_Size_Type;
-      Data       : CubedOS.Lib.Octet_Array;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Handle           : Valid_File_Handle_Type;
+      Amount           : Read_Result_Size_Type;
+      Data             : CubedOS.Lib.Octet_Array;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Pre => Amount <= Data'Length;
 
    function Write_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Write_Size_Type;
-      Data       : CubedOS.Lib.Octet_Array;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Handle         : Valid_File_Handle_Type;
+      Amount         : Write_Size_Type;
+      Data           : CubedOS.Lib.Octet_Array;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Pre => Amount <= Data'Length;
 
    function Write_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Amount     : Write_Result_Size_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Handle           : Valid_File_Handle_Type;
+      Amount           : Write_Result_Size_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Close_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Handle     : Valid_File_Handle_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Handle         : Valid_File_Handle_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
 
 
    function Is_Open_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Open_Request));
+     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Open_Request));
 
    function Is_Open_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Open_Reply));
+     (Message.Sender_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Open_Reply));
 
    function Is_Read_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Read_Request));
+     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Read_Request));
 
    function Is_Read_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Read_Reply));
+     (Message.Sender_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Read_Reply));
 
    function Is_Write_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Write_Request));
+     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Write_Request));
 
    function Is_Write_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Write_Reply));
+     (Message.Sender_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Write_Reply));
 
    function Is_Close_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Close_Request));
+     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Close_Request));
 
 
 

--- a/src/modules/cubedos-file_server-messages.adb
+++ b/src/modules/cubedos-file_server-messages.adb
@@ -13,6 +13,7 @@ with Ada.Text_IO;
 with Ada.Sequential_IO;
 with CubedOS.File_Server.API;
 with CubedOS.Lib;
+with Name_Resolver;
 
 use Ada.Text_IO;
 
@@ -60,8 +61,7 @@ package body CubedOS.File_Server.Messages is
       if Handle = API.Invalid_Handle then
          Message_Manager.Route_Message
            (API.Open_Reply_Encode
-              (Receiver_Domain => Incoming_Message.Sender_Domain,
-               Receiver   => Incoming_Message.Sender,
+              (Receiver_Address => Incoming_Message.Sender_Address,
                Request_ID => Incoming_Message.Request_ID,
                Handle     => API.Invalid_Handle));
          return;
@@ -70,8 +70,7 @@ package body CubedOS.File_Server.Messages is
       if Status = Malformed then
          Message_Manager.Route_Message
            (API.Open_Reply_Encode
-              (Receiver_Domain=> Incoming_Message.Sender_Domain,
-               Receiver   => Incoming_Message.Sender,
+              (Receiver_Address => Incoming_Message.Sender_Address,
                Request_ID => Incoming_Message.Request_ID,
                Handle     => API.Invalid_Handle));
       else
@@ -87,8 +86,7 @@ package body CubedOS.File_Server.Messages is
 
          Message_Manager.Route_Message
            (API.Open_Reply_Encode
-              (Receiver_Domain => Incoming_Message.Sender_Domain,
-               Receiver   => Incoming_Message.Sender,
+              (Receiver_Address => Incoming_Message.Sender_Address,
                Request_ID => Incoming_Message.Request_ID,
                Handle     => Handle));
       end if;
@@ -98,8 +96,7 @@ package body CubedOS.File_Server.Messages is
          -- Open failed. Send back an invalid handle.
          Message_Manager.Route_Message
            (API.Open_Reply_Encode
-              (Receiver_Domain => Incoming_Message.Sender_Domain,
-               Receiver   => Incoming_Message.Sender,
+              (Receiver_Address => Incoming_Message.Sender_Address,
                Request_ID => Incoming_Message.Request_ID,
                Handle     => API.Invalid_Handle));
    end Process_Open_Request;
@@ -131,8 +128,7 @@ package body CubedOS.File_Server.Messages is
             -- Send what we have (could be zero octets!).
             Message_Manager.Route_Message
               (API.Read_Reply_Encode
-                 (Receiver_Domain => Incoming_Message.Sender_Domain,
-                  Receiver   => Incoming_Message.Sender,
+                 (Receiver_Address => Incoming_Message.Sender_Address,
                   Request_ID => Incoming_Message.Request_ID,
                   Handle     => Handle,
                   Amount     => Size,
@@ -168,8 +164,7 @@ package body CubedOS.File_Server.Messages is
             end;
             Message_Manager.Route_Message
               (API.Write_Reply_Encode
-                 (Receiver_Domain => Incoming_Message.Sender_Domain,
-                  Receiver   => Incoming_Message.Sender,
+                 (Receiver_Address => Incoming_Message.Sender_Address,
                   Request_ID => Incoming_Message.Request_ID,
                   Handle     => Handle,
                   Amount     => Size));
@@ -220,10 +215,12 @@ package body CubedOS.File_Server.Messages is
       Incoming_Message : Message_Manager.Message_Record;
    begin
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.File_Server.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;
 
 
 end CubedOS.File_Server.Messages;
+
+

--- a/src/modules/cubedos-file_server.ads
+++ b/src/modules/cubedos-file_server.ads
@@ -10,6 +10,4 @@ with Message_Manager;
 
 package CubedOS.File_Server is
 
-    ID : constant Message_Manager.Module_ID_Type := 6;
-
 end CubedOS.File_Server;

--- a/src/modules/cubedos-file_server.ads
+++ b/src/modules/cubedos-file_server.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package CubedOS.File_Server is

--- a/src/modules/cubedos-generic_message_manager.adb
+++ b/src/modules/cubedos-generic_message_manager.adb
@@ -120,20 +120,16 @@ is
 
 
    function Make_Empty_Message
-     (Sender_Domain   : Domain_ID_Type;
-      Receiver_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Receiver   : Module_ID_Type;
+     (Sender_Address   : Message_Address;
+      Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Message_ID : Message_ID_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record;
    begin
-      Message.Sender_Domain   := Sender_Domain;
-      Message.Receiver_Domain := Receiver_Domain;
-      Message.Sender     := Sender;
-      Message.Receiver   := Receiver;
+      Message.Sender_Address := Sender_Address;
+      Message.Receiver_Address   := Receiver_Address;
       Message.Request_ID := Request_ID;
       Message.Message_ID := Message_ID;
       Message.Priority   := Priority;
@@ -152,14 +148,14 @@ is
    procedure Route_Message(Message : in Message_Record; Status : out Status_Type) is
    begin
       -- For now, let's ignore the domain and just use the receiver Module_ID only.
-      Message_Storage(Message.Receiver).Send(Message, Status);
+      Message_Storage(Message.Receiver_Address.Module_ID).Send(Message, Status);
    end Route_Message;
 
 
    procedure Route_Message(Message : in Message_Record) is
    begin
       -- For now, let's ignore the domain and just use the receiver Module_ID only.
-      Message_Storage(Message.Receiver).Unchecked_Send(Message);
+      Message_Storage(Message.Receiver_Address.Module_ID).Unchecked_Send(Message);
    end Route_Message;
 
 

--- a/src/modules/cubedos-generic_message_manager.ads
+++ b/src/modules/cubedos-generic_message_manager.ads
@@ -59,6 +59,12 @@ is
    subtype Data_Size_Type is XDR_Size_Type range 0 .. Maximum_Message_Size;
    subtype Data_Array is XDR_Array(Data_Index_Type);
 
+   -- Message Addresses hold the Domain_ID and Module_ID for Modules in a CubedOS Application
+   type Message_Address is 
+      record
+         Domain_ID : Domain_ID_Type := 0;
+         Module_ID : Module_ID_Type := 1;
+       end record;
    -- Messages currently have a priority field that is not used. The intention is to allow high
    -- priority messages to be processed earlier and without interruption. SPARK does not support
    -- dynamic task priorities, however, so the usefulness of this idea is questionable. We could
@@ -66,39 +72,27 @@ is
    -- useful.
    type Message_Record is
       record
-         Sender_Domain   : Domain_ID_Type := 0;
-         Receiver_Domain : Domain_ID_Type := 0;
-         Sender     : Module_ID_Type  := 1;  -- Would another module ID be more appropriate?
-         Receiver   : Module_ID_Type  := 1;  -- Would another module ID be more appropriate?
+         Sender_Address : Message_Address := (0, 1);
+         Receiver_Address : Message_Address := (0 , 1);
          Request_ID : Request_ID_Type := 0;
          Message_ID : Message_ID_Type := 0;
          Priority   : System.Priority := System.Default_Priority;
          Size       : Data_Size_Type  := 0;
          Payload    : Data_Array      := (others => 0);
       end record;
-   
-   type Message_Address is 
-      record
-         Domain_ID : Domain_ID_Type;
-         Module_ID : Module_ID_Type;
-       end record;
 
    -- Convenience constructor function for messages. This is used by encoding functions.
    function Make_Empty_Message
-     (Sender_Domain   : Domain_ID_Type;
-      Receiver_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Receiver   : Module_ID_Type;
+     (Sender_Address : Message_Address;
+      Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Message_ID : Message_ID_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Post=>
-         Make_Empty_Message'Result.Sender_Domain   = Sender_Domain   and
-         Make_Empty_Message'Result.Receiver_Domain = Receiver_Domain and
-         Make_Empty_Message'Result.Sender     = Sender     and
-         Make_Empty_Message'Result.Receiver   = Receiver   and
+         Make_Empty_Message'Result.Sender_Address   = Sender_Address   and
+         Make_Empty_Message'Result.Receiver_Address = Receiver_Address and
          Make_Empty_Message'Result.Request_ID = Request_ID and
          Make_Empty_Message'Result.Message_ID = Message_ID and
          Make_Empty_Message'Result.Priority   = Priority   and

--- a/src/modules/cubedos-generic_message_manager.ads
+++ b/src/modules/cubedos-generic_message_manager.ads
@@ -76,6 +76,12 @@ is
          Size       : Data_Size_Type  := 0;
          Payload    : Data_Array      := (others => 0);
       end record;
+   
+   type Message_Address is 
+      record
+         Domain_ID : Domain_ID_Type;
+         Module_ID : Module_ID_Type;
+       end record;
 
    -- Convenience constructor function for messages. This is used by encoding functions.
    function Make_Empty_Message

--- a/src/modules/cubedos-interpreter-api.adb
+++ b/src/modules/cubedos-interpreter-api.adb
@@ -12,14 +12,13 @@ use  CubedOS.Lib;
 package body CubedOS.Interpreter.API is
 
    function Clear_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
+     (Sender_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(Clear_Request), Priority);
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, Message_Type'Pos(Clear_Request), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -27,14 +26,13 @@ package body CubedOS.Interpreter.API is
 
 
    function Set_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
+     (Sender_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(Set_Request), Priority);
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, Message_Type'Pos(Set_Request), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -42,8 +40,7 @@ package body CubedOS.Interpreter.API is
 
 
    function Set_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
+     (Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Status     : Status_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
@@ -51,7 +48,7 @@ package body CubedOS.Interpreter.API is
       -- The skeletal message knows its sender (this module).
       Message : Message_Record :=
         Make_Empty_Message
-          (Domain_ID, Receiver_Domain, ID, Receiver, Request_ID, Message_Type'Pos(Set_Reply), Priority);
+          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Set_Reply), Priority);
 
       Position : Data_Index_Type;
       Last     : Data_Index_Type;
@@ -71,14 +68,13 @@ package body CubedOS.Interpreter.API is
 
 
    function Add_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
+     (Sender_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain, Domain_ID, Sender, ID, Request_ID, Message_Type'Pos(Add_Request), Priority);
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, Message_Type'Pos(Add_Request), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -86,8 +82,7 @@ package body CubedOS.Interpreter.API is
 
 
    function Add_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
+     (Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
       Status     : Status_Type;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
@@ -95,7 +90,7 @@ package body CubedOS.Interpreter.API is
       -- The skeletal message knows its sender (this module).
       Message : Message_Record :=
         Make_Empty_Message
-          (Domain_ID, Receiver_Domain, ID, Receiver, Request_ID, Message_Type'Pos(Add_Reply), Priority);
+          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Add_Reply), Priority);
 
       Position : Data_Index_Type;
       Last     : Data_Index_Type;

--- a/src/modules/cubedos-interpreter-api.ads
+++ b/src/modules/cubedos-interpreter-api.ads
@@ -10,6 +10,8 @@
 pragma SPARK_Mode(On);
 
 with Message_Manager;  use Message_Manager;
+with Name_Resolver;
+
 with System;
 
 package CubedOS.Interpreter.API is
@@ -24,56 +26,51 @@ package CubedOS.Interpreter.API is
       Add_Reply);     -- Indicates if the addition was successful. Failure => insufficient space.
 
    function Clear_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    with Global => null;
 
    function Set_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    with Global => null;
 
    function Set_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Status     : Status_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Status           : Status_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
    with Global => null;
 
    function Add_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    with Global => null;
 
    function Add_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Status     : Status_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Status           : Status_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
    with Global => null;
 
    function Is_Clear_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Clear_Request));
+     (Message.Receiver_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Clear_Request));
 
    function Is_Set_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Set_Request));
+     (Message.Receiver_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Set_Request));
 
    function Is_Set_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Set_Reply));
+     (Message.Sender_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Set_Reply));
 
    function Is_Add_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Add_Request));
+     (Message.Receiver_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Add_Request));
 
    function Is_Add_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Add_Reply));
+     (Message.Sender_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Add_Reply));
 
    procedure Clear_Request_Decode
      (Message : in  Message_Record;

--- a/src/modules/cubedos-interpreter-messages.adb
+++ b/src/modules/cubedos-interpreter-messages.adb
@@ -81,7 +81,7 @@ package body CubedOS.Interpreter.Messages is
       Initialize;
 
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.Interpreter.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/src/modules/cubedos-interpreter-messages.ads
+++ b/src/modules/cubedos-interpreter-messages.ads
@@ -7,6 +7,7 @@
 pragma SPARK_Mode(On);
 
 with System;
+with Name_Resolver;
 
 package CubedOS.Interpreter.Messages is
 

--- a/src/modules/cubedos-interpreter.ads
+++ b/src/modules/cubedos-interpreter.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package CubedOS.Interpreter is

--- a/src/modules/cubedos-interpreter.ads
+++ b/src/modules/cubedos-interpreter.ads
@@ -10,6 +10,4 @@ with Message_Manager;
 
 package CubedOS.Interpreter is
 
-   ID : constant Message_Manager.Module_ID_Type := 8;
-
 end CubedOS.Interpreter;

--- a/src/modules/cubedos-log_server-api.adb
+++ b/src/modules/cubedos-log_server-api.adb
@@ -16,33 +16,29 @@ package body CubedOS.Log_Server.API is
    use type XDR.XDR_Unsigned;
 
    procedure Log_Message
-     (Sender_Domain : in Domain_ID_Type;
-      Sender        : in Module_ID_Type;
-      Log_Level     : in Log_Level_Type;
-      Text          : in String)
+     (Sender_Address : in Message_Address;
+      Log_Level      : in Log_Level_Type;
+      Text           : in String)
    is
    begin
-      Message_Manager.Route_Message(Log_Text_Encode(Sender_Domain, Sender, 0, Log_Level, Text));
+      Message_Manager.Route_Message(Log_Text_Encode(Sender_Address, 0, Log_Level, Text));
    end Log_Message;
 
 
    function Log_Text_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Log_Level  : Log_Level_Type;
-      Text       : String;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Log_Level      : Log_Level_Type;
+      Text           : String;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Sender_Domain,
-           Receiver_Domain => Domain_ID,
-           Sender     => Sender,
-           Receiver   => ID,
-           Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Log_Text),
-           Priority   => Priority);
+          (Sender_Address   => Sender_Address,
+           Receiver_Address => Name_Resolver.Log_Server,
+           Request_ID       => Request_ID,
+           Message_ID       => Message_Type'Pos(Log_Text),
+           Priority         => Priority);
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin

--- a/src/modules/cubedos-log_server-api.ads
+++ b/src/modules/cubedos-log_server-api.ads
@@ -10,6 +10,7 @@
 pragma SPARK_Mode(On);
 
 with Message_Manager;  use Message_Manager;
+with Name_Resolver;
 with System;
 
 package CubedOS.Log_Server.API is
@@ -34,27 +35,25 @@ package CubedOS.Log_Server.API is
 
    -- Convenience procedure that creates and sends a log message.
    procedure Log_Message
-     (Sender_Domain : in Domain_ID_Type;
-      Sender        : in Module_ID_Type;
-      Log_Level     : in Log_Level_Type;
-      Text          : in String)
+     (Sender_Address : in Message_Address;
+      Log_Level      : in Log_Level_Type;
+      Text           : in String)
      with Pre => Text'Length <= Maximum_Log_Message_Size;
 
 
    function Log_Text_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Log_Level  : Log_Level_Type;
-      Text       : String;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Log_Level      : Log_Level_Type;
+      Text           : String;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Pre    => Text'Length <= Maximum_Log_Message_Size;
 
 
    function Is_A_Log_Text(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Log_Text));
+     (Message.Receiver_Address = Name_Resolver.Log_Server and Message.Message_ID = Message_Type'Pos(Log_Text));
 
 
    procedure Log_Text_Decode

--- a/src/modules/cubedos-log_server-messages.adb
+++ b/src/modules/cubedos-log_server-messages.adb
@@ -7,6 +7,7 @@
 pragma SPARK_Mode(On);
 
 with CubedOS.Log_Server.API;
+with Name_Resolver;
 
 package body CubedOS.Log_Server.Messages is
    use Message_Manager;
@@ -33,8 +34,8 @@ package body CubedOS.Log_Server.Messages is
       if Status = Success then
          Ada.Text_IO.Put_Line
            (Level_Strings(Log_Level) &
-            " ("  & Domain_ID_Type'Image(Message.Sender_Domain) &
-            ","   & Module_ID_Type'Image(Message.Sender) &
+            " ("  & Domain_ID_Type'Image(Message.Sender_Address.Domain_ID) &
+            ","   & Module_ID_Type'Image(Message.Sender_Address.Module_ID) &
             "): " & Text(1 .. Size));
       end if;
    end Handle_Log_Text;
@@ -63,7 +64,7 @@ package body CubedOS.Log_Server.Messages is
       Incoming_Message : Message_Manager.Message_Record;
    begin
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.Log_Server.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/src/modules/cubedos-log_server.ads
+++ b/src/modules/cubedos-log_server.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package CubedOS.Log_Server is

--- a/src/modules/cubedos-log_server.ads
+++ b/src/modules/cubedos-log_server.ads
@@ -10,6 +10,4 @@ with Message_Manager;
 
 package CubedOS.Log_Server is
 
-   ID : constant Message_Manager.Module_ID_Type := 2;
-
 end CubedOS.Log_Server;

--- a/src/modules/cubedos-publish_subscribe_server-api.adb
+++ b/src/modules/cubedos-publish_subscribe_server-api.adb
@@ -18,18 +18,15 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Reason  => "The last value of Last is not needed");
 
    function Subscribe_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender     : in Module_ID_Type;
+     (Sender_Address : in Message_Address;
       Request_ID : in Request_ID_Type;
       Channel    : in Channel_ID_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Sender_Domain,
-           Receiver_Domain => Domain_ID,
-           Sender     => Sender,
-           Receiver   => ID,
+          (Sender_Address   => Sender_Address,
+           Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Subscribe_Request),
            Priority   => Priority);
@@ -44,8 +41,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
 
 
    function Subscribe_Reply_Encode
-     (Receiver_Domain : in Domain_ID_Type;
-      Receiver   : in Module_ID_Type;
+     (Receiver_Address : in Message_Address;
       Request_ID : in Request_ID_Type;
       Channel    : in Channel_ID_Type;
       Status     : in Status_Type;
@@ -53,10 +49,8 @@ package body CubedOS.Publish_Subscribe_Server.API is
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Domain_ID,
-           Receiver_Domain => Receiver_Domain,
-           Sender     => ID,
-           Receiver   => Receiver,
+          (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
+           Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Subscribe_Reply),
            Priority   => Priority);
@@ -73,18 +67,15 @@ package body CubedOS.Publish_Subscribe_Server.API is
 
 
    function Unsubscribe_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender     : in Module_ID_Type;
+     (Sender_Address : Message_Address;
       Request_ID : in Request_ID_Type;
       Channel    : in Channel_ID_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Sender_Domain,
-           Receiver_Domain => Domain_ID,
-           Sender     => Sender,
-           Receiver   => ID,
+          (Sender_Address => Sender_Address,
+           Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Unsubscribe_Request),
            Priority   => Priority);
@@ -99,8 +90,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
 
 
    function Unsubscribe_Reply_Encode
-     (Receiver_Domain : in Domain_ID_Type;
-      Receiver   : in Module_ID_Type;
+     (Receiver_Address : in Message_Address;
       Request_ID : in Request_ID_Type;
       Channel    : in Channel_ID_Type;
       Status     : in Status_Type;
@@ -108,10 +98,8 @@ package body CubedOS.Publish_Subscribe_Server.API is
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Domain_ID,
-           Receiver_Domain => Receiver_Domain,
-           Sender     => ID,
-           Receiver   => Receiver,
+          (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
+           Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Unsubscribe_Reply),
            Priority   => Priority);
@@ -128,8 +116,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
 
 
    function Publish_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender       : in Module_ID_Type;
+     (Sender_Address : in Message_Address;
       Request_ID   : in Request_ID_Type;
       Channel      : in Channel_ID_Type;
       Message_Data : in CubedOS.Lib.Octet_Array;
@@ -137,10 +124,8 @@ package body CubedOS.Publish_Subscribe_Server.API is
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Sender_Domain,
-           Receiver_Domain => Domain_ID,
-           Sender     => Sender,
-           Receiver   => ID,
+          (Sender_Address => Sender_Address,
+           Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Publish_Request),
            Priority   => Priority);
@@ -159,8 +144,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
 
 
    function Publish_Reply_Encode
-     (Receiver_Domain : in Domain_ID_Type;
-      Receiver   : in Module_ID_Type;
+     (Receiver_Address : in Message_Address;
       Request_ID : in Request_ID_Type;
       Channel    : in Channel_ID_Type;
       Status     : in Status_Type;
@@ -168,10 +152,8 @@ package body CubedOS.Publish_Subscribe_Server.API is
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Domain_ID,
-           Receiver_Domain => Receiver_Domain,
-           Sender     => ID,
-           Receiver   => Receiver,
+          (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
+           Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Publish_Reply),
            Priority   => Priority);
@@ -188,8 +170,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
 
 
    function Publish_Result_Encode
-     (Receiver_Domain : in Domain_ID_Type;
-      Receiver   : in Module_ID_Type;
+     (Receiver_Address : in Message_Address;
       Request_ID : in Request_ID_Type;
       Channel    : in Channel_ID_Type;
       Message_Data : in CubedOS.Lib.Octet_Array;
@@ -197,10 +178,8 @@ package body CubedOS.Publish_Subscribe_Server.API is
    is
       Message : Message_Record :=
         Make_Empty_Message
-          (Sender_Domain   => Domain_ID,
-           Receiver_Domain => Receiver_Domain,
-           Sender     => ID,
-           Receiver   => Receiver,
+          (Sender_Address => Name_Resolver.Publish_Subscribe_Server,
+           Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Publish_Result),
            Priority   => Priority);

--- a/src/modules/cubedos-publish_subscribe_server-api.ads
+++ b/src/modules/cubedos-publish_subscribe_server-api.ads
@@ -11,6 +11,7 @@ pragma SPARK_Mode(On);
 
 with CubedOS.Lib;
 with Message_Manager;  use Message_Manager;
+with Name_Resolver;
 with System;
 
 package CubedOS.Publish_Subscribe_Server.API is
@@ -28,91 +29,84 @@ package CubedOS.Publish_Subscribe_Server.API is
       Publish_Result);     -- Delivery of data published to a channel.
 
    function Subscribe_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Channel        : Channel_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Subscribe_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Status     : Status_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Channel          : Channel_ID_Type;
+      Status           : Status_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Unsubscribe_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Channel        : Channel_ID_Type;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Unsubscribe_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Status     : Status_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Channel          : Channel_ID_Type;
+      Status           : Status_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Publish_Request_Encode
-     (Sender_Domain : Domain_ID_Type;
-      Sender     : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Message_Data : CubedOS.Lib.Octet_Array;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address;
+      Request_ID     : Request_ID_Type;
+      Channel        : Channel_ID_Type;
+      Message_Data   : CubedOS.Lib.Octet_Array;
+      Priority       : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Pre => Message_Data'Length <= Data_Size_Type'Last - 8;
 
    function Publish_Reply_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Status     : Status_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : Message_Address;
+      Request_ID       : Request_ID_Type;
+      Channel          : Channel_ID_Type;
+      Status           : Status_Type;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Publish_Result_Encode
-     (Receiver_Domain : Domain_ID_Type;
-      Receiver   : Module_ID_Type;
-      Request_ID : Request_ID_Type;
-      Channel    : Channel_ID_Type;
-      Message_Data : CubedOS.Lib.Octet_Array;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address :  Message_Address;
+      Request_ID       : Request_ID_Type;
+      Channel          : Channel_ID_Type;
+      Message_Data     : CubedOS.Lib.Octet_Array;
+      Priority         : System.Priority := System.Default_Priority) return Message_Record
      with
        Global => null,
        Pre => Message_Data'Length <= Data_Size_Type'Last - 8;
 
 
    function Is_Subscribe_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Subscribe_Request));
+     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Subscribe_Request));
 
    function Is_Subscribe_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Subscribe_Reply));
+     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Subscribe_Reply));
 
    function Is_Unsubscribe_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Unsubscribe_Request));
+     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Unsubscribe_Request));
 
    function Is_Unsubscribe_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Unsubscribe_Reply));
+     (Message.Sender_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Unsubscribe_Reply));
 
    function Is_Publish_Request(Message : Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos(Publish_Request));
+     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Publish_Request));
 
    function Is_Publish_Reply(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Publish_Reply));
+     (Message.Sender_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Publish_Reply));
 
    function Is_Publish_Result(Message : Message_Record) return Boolean is
-     (Message.Sender = ID and Message.Message_ID = Message_Type'Pos(Publish_Result));
+     (Message.Sender_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Publish_Result));
 
 
    procedure Subscribe_Request_Decode

--- a/src/modules/cubedos-publish_subscribe_server-messages.ads
+++ b/src/modules/cubedos-publish_subscribe_server-messages.ads
@@ -8,7 +8,7 @@ pragma SPARK_Mode(On);
 pragma Profile(Ravenscar);
 pragma Partition_Elaboration_Policy(Sequential);
 pragma Task_Dispatching_Policy(FIFO_Within_Priorities);
-pragma Queing_Policy(FIFO_Within_Priorities);
+pragma Queuing_Policy(FIFO_Within_Priorities);
 
 with System;
 

--- a/src/modules/cubedos-publish_subscribe_server-messages.ads
+++ b/src/modules/cubedos-publish_subscribe_server-messages.ads
@@ -7,15 +7,17 @@
 pragma SPARK_Mode(On);
 pragma Profile(Ravenscar);
 pragma Partition_Elaboration_Policy(Sequential);
+
+-- Why are these here?
 pragma Task_Dispatching_Policy(FIFO_Within_Priorities);
-pragma Queuing_Policy(FIFO_Within_Priorities);
+pragma Queuing_Policy(FIFO_Queuing);
 
 with System;
 
 package CubedOS.Publish_Subscribe_Server.Messages
   with
     Abstract_State => Database,
-    Initializes => (Database, Message_Loop)
+    Initializes => Database
 is
 
    task type Message_Loop

--- a/src/modules/cubedos-publish_subscribe_server.ads
+++ b/src/modules/cubedos-publish_subscribe_server.ads
@@ -18,6 +18,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package CubedOS.Publish_Subscribe_Server is

--- a/src/modules/cubedos-publish_subscribe_server.ads
+++ b/src/modules/cubedos-publish_subscribe_server.ads
@@ -22,6 +22,4 @@ with Message_Manager;
 
 package CubedOS.Publish_Subscribe_Server is
 
-   ID : constant Message_Manager.Module_ID_Type := 3;
-
 end CubedOS.Publish_Subscribe_Server;

--- a/src/modules/cubedos-time_server-api.adb
+++ b/src/modules/cubedos-time_server-api.adb
@@ -18,13 +18,12 @@ package body CubedOS.Time_Server.API is
       Reason  => "The last value of Last is not needed");
 
    function Relative_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender        : in Module_ID_Type;
-      Request_ID    : in Request_ID_Type;
-      Tick_Interval : in Ada.Real_Time.Time_Span;
-      Request_Type  : in Series_Type;
-      Series_ID     : in Series_ID_Type;
-      Priority      : in System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : in Message_Address;
+      Request_ID     : in Request_ID_Type;
+      Tick_Interval  : in Ada.Real_Time.Time_Span;
+      Request_Type   : in Series_Type;
+      Series_ID      : in Series_ID_Type;
+      Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message    : Message_Record;
       Position   : Data_Index_Type;
@@ -32,10 +31,8 @@ package body CubedOS.Time_Server.API is
       Interval   : constant Duration := Ada.Real_Time.To_Duration(Tick_Interval);
    begin
       Message := Make_Empty_Message
-        (Sender_Domain   => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address   => Sender_Address,
+         Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Relative_Request),
          Priority   => Priority);
@@ -52,12 +49,11 @@ package body CubedOS.Time_Server.API is
 
 
    function Absolute_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender     : in Module_ID_Type;
-      Request_ID : in Request_ID_Type;
-      Tick_Time  : in Ada.Real_Time.Time;
-      Series_ID  : in Series_ID_Type;
-      Priority   : in System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : in Message_Address;
+      Request_ID     : in Request_ID_Type;
+      Tick_Time      : in Ada.Real_Time.Time;
+      Series_ID      : in Series_ID_Type;
+      Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message    : Message_Record;
       Position   : Data_Index_Type;
@@ -66,10 +62,8 @@ package body CubedOS.Time_Server.API is
       Fraction   : Ada.Real_Time.Time_Span;
    begin
       Message := Make_Empty_Message
-        (Sender_Domain   => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address => Sender_Address,
+         Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Absolute_Request),
          Priority   => Priority);
@@ -86,18 +80,15 @@ package body CubedOS.Time_Server.API is
 
 
    function Tick_Reply_Encode
-     (Receiver_Domain : in Domain_ID_Type;
-      Receiver   : in Module_ID_Type;
-      Request_ID : in Request_ID_Type;
-      Series_ID  : in Series_ID_Type;
-      Count      : in Series_Count_Type;
-      Priority   : in System.Priority := System.Default_Priority) return Message_Record
+     (Receiver_Address : in Message_Address;
+      Request_ID       : in Request_ID_Type;
+      Series_ID        : in Series_ID_Type;
+      Count            : in Series_Count_Type;
+      Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
       Result : Message_Record := Make_Empty_Message
-        (Sender_Domain   => Domain_ID,
-         Receiver_Domain => Receiver_Domain,
-         Sender     => ID,
-         Receiver   => Receiver,
+        (Sender_Address   => Name_Resolver.Time_Server,
+         Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Tick_Reply),
          Priority   => Priority);
@@ -117,21 +108,18 @@ package body CubedOS.Time_Server.API is
 
 
    function Cancel_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender     : in Module_ID_Type;
-      Request_ID : in Request_ID_Type;
-      Series_ID  : in Series_ID_Type;
-      Priority   : in System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : in Message_Address;
+      Request_ID     : in Request_ID_Type;
+      Series_ID      : in Series_ID_Type;
+      Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message    : Message_Record;
       Position   : Data_Index_Type;
       Last       : Data_Index_Type;
    begin
       Message := Make_Empty_Message
-        (Sender_Domain   => Sender_Domain,
-         Receiver_Domain => Domain_ID,
-         Sender     => Sender,
-         Receiver   => ID,
+        (Sender_Address   => Sender_Address,
+         Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Cancel_Request),
          Priority   => Priority);

--- a/src/modules/cubedos-time_server-api.ads
+++ b/src/modules/cubedos-time_server-api.ads
@@ -12,6 +12,7 @@ pragma SPARK_Mode(On);
 with Ada.Real_Time;
 with Message_Manager;
 with System;
+with Name_Resolver;
 
 use Message_Manager;
 
@@ -52,13 +53,12 @@ package CubedOS.Time_Server.API is
    -- @param Series_ID The ID number for the series (selected by the caller and thus only
    --   meaningful to the requesting module).
    function Relative_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender        : in Module_ID_Type;
-      Request_ID    : in Request_ID_Type;
-      Tick_Interval : in Ada.Real_Time.Time_Span;
-      Request_Type  : in Series_Type;
-      Series_ID     : in Series_ID_Type;
-      Priority      : in System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : in Message_Address;
+      Request_ID     : in Request_ID_Type;
+      Tick_Interval  : in Ada.Real_Time.Time_Span;
+      Request_Type   : in Series_Type;
+      Series_ID      : in Series_ID_Type;
+      Priority       : in System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    -- Return a message for requesting a single tick message at a specific, absolute time.
@@ -67,12 +67,11 @@ package CubedOS.Time_Server.API is
    -- @param Series_ID The ID number of the series (selected by the caller and thus only
    --   meaningful to the requesting module).
    function Absolute_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender     : in Module_ID_Type;
-      Request_ID : in Request_ID_Type;
-      Tick_Time  : in Ada.Real_Time.Time;
-      Series_ID  : in Series_ID_Type;
-      Priority   : in System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : in Message_Address;
+      Request_ID     : in Request_ID_Type;
+      Tick_Time      : in Ada.Real_Time.Time;
+      Series_ID      : in Series_ID_Type;
+      Priority       : in System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    -- The tick messages themselves.
@@ -83,36 +82,34 @@ package CubedOS.Time_Server.API is
    --   count sequence). Should the count reach Series_Count_Type'Last, the series is canceled
    --   after a Tick_Reply with that count is sent.
    function Tick_Reply_Encode
-     (Receiver_Domain : in Domain_ID_Type;
-      Receiver   : in Module_ID_Type;
-      Request_ID : in Request_ID_Type;
-      Series_ID  : in Series_ID_Type;
-      Count      : in Series_Count_Type;
-      Priority   : in System.Priority := System.Default_Priority) return Message_Record;
+     (Receiver_Address : in Message_Address;
+      Request_ID       : in Request_ID_Type;
+      Series_ID        : in Series_ID_Type;
+      Count            : in Series_Count_Type;
+      Priority         : in System.Priority := System.Default_Priority) return Message_Record;
 
    -- Return a message for canceling previous tick requests (of any kind).
    -- @param Series_ID The ID number of the series being canceled. If the series does not
    --   exist or has already been canceled or removed (due to being a one shot series that has
    --   already fired), there is no effect.
    function Cancel_Request_Encode
-     (Sender_Domain : in Domain_ID_Type;
-      Sender     : in Module_ID_Type;
-      Request_ID : in Request_ID_Type;
-      Series_ID  : in Series_ID_Type;
-      Priority   : in System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : in Message_Address;
+      Request_ID     : in Request_ID_Type;
+      Series_ID      : in Series_ID_Type;
+      Priority       : in System.Priority := System.Default_Priority) return Message_Record
      with Global => null;
 
    function Is_Relative_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos (Relative_Request));
+     (Message.Receiver_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Relative_Request));
 
    function Is_Absolute_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos (Absolute_Request));
+     (Message.Receiver_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Absolute_Request));
 
    function Is_Tick_Reply(Message : in Message_Record) return Boolean is
-      (Message.Sender = ID and Message.Message_ID = Message_Type'Pos (Tick_Reply));
+      (Message.Sender_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Tick_Reply));
 
    function Is_Cancel_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver = ID and Message.Message_ID = Message_Type'Pos (Cancel_Request));
+     (Message.Receiver_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Cancel_Request));
 
    -- Decode Relative_Request messages. See Relative_Request_Encode for information about the
    -- parameters.

--- a/src/modules/cubedos-time_server-messages.adb
+++ b/src/modules/cubedos-time_server-messages.adb
@@ -293,7 +293,7 @@ package body CubedOS.Time_Server.Messages
       Incoming_Message : Message_Manager.Message_Record;
    begin
       loop
-         Message_Manager.Fetch_Message(ID, Incoming_Message);
+         Message_Manager.Fetch_Message(Name_Resolver.Time_Server.Module_ID, Incoming_Message);
          Process(Incoming_Message);
       end loop;
    end Message_Loop;

--- a/src/modules/cubedos-time_server-messages.adb
+++ b/src/modules/cubedos-time_server-messages.adb
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+with Name_Resolver;
 with CubedOS.Time_Server.API;
 use  CubedOS.Time_Server.API;
 
@@ -22,6 +23,7 @@ package body CubedOS.Time_Server.Messages
 
    subtype Restricted_Module_ID is Positive range 2 .. Module_ID_Type'Last;
 
+   -- Should Series_Record hold the Domain_ID?
    type Series_Record is
       record
          Module_ID : Restricted_Module_ID := Restricted_Module_ID'First;
@@ -135,8 +137,7 @@ package body CubedOS.Time_Server.Messages
                if Current_Series.Is_Used and then Current_Series.Next <= Current_Time then
                   Route_Message
                     (Tick_Reply_Encode
-                       (Receiver_Domain => Domain_ID,
-                        Receiver   => Current_Series.Module_ID,
+                       (Receiver_Address => (Name_Resolver.Time_Server.Domain_ID, Current_Series.Module_ID),
                         Request_ID => 0,
                         Series_ID  => Current_Series.ID,
                         Count      => Current_Series.Count));
@@ -198,8 +199,8 @@ package body CubedOS.Time_Server.Messages
          -- a tick request to itself, that logic error should perhaps be logged somehow. It
          -- would be nice to statically show that situation can never happen.
          --
-         if Incoming_Message.Sender in Restricted_Module_ID then
-            Series.Module_ID := Incoming_Message.Sender;
+         if Incoming_Message.Sender_Address.Module_ID in Restricted_Module_ID then
+            Series.Module_ID := Incoming_Message.Sender_Address.Module_ID;
             Series.ID        := Series_ID;
             Series.Kind      := Request_Type;
             Series.Interval  := Tick_Interval;
@@ -228,8 +229,8 @@ package body CubedOS.Time_Server.Messages
          -- a tick request to itself, that logic error should perhaps be logged somehow. It
          -- would be nice to statically show that situation can never happen.
          --
-         if Incoming_Message.Sender in Restricted_Module_ID then
-            Series.Module_ID := Incoming_Message.Sender;
+         if Incoming_Message.Sender_Address.Module_ID in Restricted_Module_ID then
+            Series.Module_ID := Incoming_Message.Sender_Address.Module_ID;
             Series.ID        := Series_ID;
             Series.Kind      := One_Shot;
             Series.Interval  := Ada.Real_Time.Time_Span_Zero;
@@ -255,8 +256,8 @@ package body CubedOS.Time_Server.Messages
       -- a cancel request to itself, that logic error should perhaps be logged somehow. It
       -- would be nice to statically show that situation can never happen.
       --
-      if Status = Success and Incoming_Message.Sender in Restricted_Module_ID then
-         Series_Database.Remove_Series_Record(Incoming_Message.Sender, Series_ID);
+      if Status = Success and Incoming_Message.Sender_Address.Module_ID in Restricted_Module_ID then
+         Series_Database.Remove_Series_Record(Incoming_Message.Sender_Address.Module_ID, Series_ID);
       end if;
    end Process_Cancel_Request;
 

--- a/src/modules/cubedos-time_server.ads
+++ b/src/modules/cubedos-time_server.ads
@@ -6,6 +6,7 @@
 --------------------------------------------------------------------------------
 pragma SPARK_Mode(On);
 
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
 with Message_Manager;
 
 package CubedOS.Time_Server is

--- a/src/modules/cubedos-time_server.ads
+++ b/src/modules/cubedos-time_server.ads
@@ -10,6 +10,4 @@ with Message_Manager;
 
 package CubedOS.Time_Server is
 
-   ID : constant Message_Manager.Module_ID_Type := 4;
-
 end CubedOS.Time_Server;

--- a/src/name_resolver.ads
+++ b/src/name_resolver.ads
@@ -1,0 +1,47 @@
+--------------------------------------------------------------------------------
+-- FILE    : name_resolver.ads
+-- SUBJECT : Specification of a package holding Domain IDs and Module IDs
+-- AUTHOR  : (C) Copyright 2022 by Vermont Technical College
+--
+-- Each CubedOS application must provide a version of this file that maps "well-
+-- known" names to (Domain_ID, Module_ID) pairs. The precise ID asssigments are
+-- arbitrary. CubedOS applications should use the names to get the application-
+-- specific ID assignments.
+--
+-- Each domain must instantiate the generic message manager to include enough
+-- mailboxes to hold the highest numbered Module_ID in that domain. That instantiation
+-- *must* be called Message_Manager (this name is hard-coded in the modules). One
+-- consequence of this is that each domain must be in a separate executable.
+--
+-- Copy this file to your CubedOS application code base and edit it to mention
+-- only the modules you need, including your application-specific modules. Assign
+-- IDs "compactly" (with no gaps in the numbering) so that you can create a
+-- Message_Manager instantiation with the minimum number of mailboxes.
+--------------------------------------------------------------------------------
+with Message_Manager; use Message_Manager;
+
+package Name_Resolver is
+
+   -- Core Modules.
+   -- Declarations that are commented out are for currently unimplemented core modules.
+   -- Note that the "Name_Resolver" module is reserved for a dynamic name resolver,
+   -- which may never get implemented depending on how well this static system works!
+
+   -- Name_Resolver            : constant Message_Address := (0, 1);
+   Log_Server               : constant Message_Address := (0, 2);
+   Publish_Subscribe_Server : constant Message_Address := (0, 3);
+   Time_Server              : constant Message_Address := (0, 4);
+   -- Event_Server             : constant Message_Address := (0, 5);
+   File_Server              : constant Message_Address := (0, 6);
+   -- Table_Server             : constant Message_Address := (0, 7);
+   Interpreter              : constant Message_Address := (0, 8);
+
+   -- Application-Specific Modules.
+   -- Make up names as you see fit (typically the same as your module's top level package).
+   -- Be sure there are no duplicate (Domain_ID, Module_ID) pairs.
+   -- The  names below are examples.
+
+   -- Echo_Client             : constant Message_Address := (0, 1);
+   -- Echo_Server             : constant Message_Address := (0, 2);
+
+end Name_Resolver;


### PR DESCRIPTION
A package specification named `Name_Resolver` has been added to the sample programs and the [top-level source directory ](https://github.com/cubesatlab/cubedos/tree/name-resolver/src)(to satisfy test programs and serve as a template for new applications). 

[`Name_Resolver`](https://github.com/cubesatlab/cubedos/blob/name-resolver/src/name_resolver.ads) includes hard-coded constants of type [`Message_Address`](https://github.com/cubesatlab/cubedos/blob/3454e18ab06bd65d160a0662c6bc9a29c0cb5f24/src/modules/cubedos-generic_message_manager.ads#L63) - a new type declared in `Generic_Message_Manager` that contains a field for `Domain_ID` and a field for `Module_ID` - for each module in a CubedOS application.    

This assumes the application developer numbers all modules (both domain and module IDs) in the application, including the core modules.  Individual modules are no longer knowledgable of their `Domain_ID` and `Modue_ID`.  Instead, the `Name_Resolver` will now be used to reference module addresses in a CubedOS application.  

The declaration of the [`Message_Record`](https://github.com/cubesatlab/cubedos/blob/3454e18ab06bd65d160a0662c6bc9a29c0cb5f24/src/modules/cubedos-generic_message_manager.ads#L73) type has also been updated to adopt `Message_Address` types instead of individual domain and module IDs.  

More thought should be put into adding `Domain_ID` to the [`Series_Record`](https://github.com/cubesatlab/cubedos/blob/3454e18ab06bd65d160a0662c6bc9a29c0cb5f24/src/modules/cubedos-time_server-messages.adb#L27) type and [`Subscription_Map_Type`](https://github.com/cubesatlab/cubedos/blob/3454e18ab06bd65d160a0662c6bc9a29c0cb5f24/src/modules/cubedos-publish_subscribe_server-messages.adb#L21) type in order to handle messages across domains.