### PR TITLE
Alire executable crate sample program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ CubedOS.pdf
 # Generated API packages
 src/modules/MXDR/*.ads
 src/modules/MXDR/*.adb
+
+*.DS_Store

--- a/samples/Echo_Alire/.gitignore
+++ b/samples/Echo_Alire/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/bin/
+/alire/
+/config/

--- a/samples/Echo_Alire/README.md
+++ b/samples/Echo_Alire/README.md
@@ -1,0 +1,15 @@
+
+Demo
+====
+
+This folder contains an Alire executable crate configuration for the CubedOS Echo demonstration program.  The Echo program consists of two modules that trade
+messages back and forth (echo client/server modules). This is effectively the "Hello, World"
+program of message passing systems.  For more on the Echo program, see `samples/Echo`.
+
+This program is intended to be used with the Alire package manager. 
+
+Setup
+=====
+
+- install [Alire](https://alire.ada.dev/docs/#getting-started)
+- build and run the executable using `alr run`

--- a/samples/Echo_Alire/alire.toml
+++ b/samples/Echo_Alire/alire.toml
@@ -1,0 +1,9 @@
+name = "echo"
+description = "Shiny new project"
+version = "0.1.0-dev"
+
+authors = ["Sevo"]
+maintainers = ["Sevo <sgolnaza@gmail.com>"]
+maintainers-logins = ["sevanbadal"]
+
+executables = ["echo"]

--- a/samples/Echo_Alire/echo.gpr
+++ b/samples/Echo_Alire/echo.gpr
@@ -1,0 +1,22 @@
+with "config/echo_config.gpr";
+project Echo is
+
+   for Source_Dirs use ("src/", "config/", "../../src", "../../src/modules", "../../src/library");
+   for Object_Dir use "obj/" & Echo_Config.Build_Profile;
+   for Create_Missing_Dirs use "True";
+   for Exec_Dir use "bin";
+   for Main use ("echo.adb");
+
+   package Compiler is
+      for Default_Switches ("Ada") use Echo_Config.Ada_Compiler_Switches;
+   end Compiler;
+
+   package Binder is
+      for Switches ("Ada") use ("-Es"); --  Symbolic traceback
+   end Binder;
+
+   package Install is
+      for Artifacts (".") use ("share");
+   end Install;
+
+end Echo;

--- a/samples/Echo_Alire/src/echo.adb
+++ b/samples/Echo_Alire/src/echo.adb
@@ -1,0 +1,30 @@
+--------------------------------------------------------------------------------
+-- FILE   : main.adb
+-- SUBJECT: Main program of the echo client/server CubedOS demonstration program.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with Ada.Real_Time;
+with System;
+
+-- Bring in the necessary modules, both from CubedOS and from this application.
+
+with Echo_Client.Messages;
+with Echo_Server.Messages;
+
+pragma Unreferenced(Echo_Client.Messages);
+pragma Unreferenced(Echo_Server.Messages);
+
+procedure Echo is
+
+   pragma Priority(System.Priority'First);
+   use type Ada.Real_Time.Time;
+   Next_Release : Ada.Real_Time.Time := Ada.Real_Time.Clock + Ada.Real_Time.Milliseconds(1000);
+begin
+   -- This loop does nothing at the lowest priority. It spends most of its time sleeping.
+   loop
+      delay until Next_Release;
+      Next_Release := Next_Release + Ada.Real_Time.Milliseconds(1000);
+      return;
+   end loop;
+end Echo;

--- a/samples/Echo_Alire/src/echo_client-messages.adb
+++ b/samples/Echo_Alire/src/echo_client-messages.adb
@@ -1,0 +1,127 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_client-messages.adb
+-- SUBJECT: Body of a package that implements the main part of the module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with Ada.Text_IO;
+with Ada.Real_Time;
+
+with Echo_Server.API;
+with Name_Resolver;
+
+package body Echo_Client.Messages is
+   use Message_Manager;
+   use type Ada.Real_Time.Time;
+   use type Echo_Server.API.Status_Type;
+
+   package Duration_IO is new Ada.Text_IO.Fixed_IO(Duration);
+   package Request_IO  is new Ada.Text_IO.Modular_IO(Request_ID_Type);
+
+   Send_Time      : Ada.Real_Time.Time;
+   Receive_Time   : Ada.Real_Time.Time;
+   Request_Number : Request_ID_Type := 0;
+
+   Outgoing_Message : Message_Record;
+
+
+   procedure Initialize is
+   begin
+      -- Send the first message!
+     Send_Time := Ada.Real_Time.Clock;
+     Outgoing_Message := Echo_Server.API.Ping_Request_Encode
+        (Sender_Address => Name_Resolver.Echo_Client,
+         Request_ID    => Request_Number);
+      Route_Message(Outgoing_Message);
+   end Initialize;
+
+   -------------------
+   -- Message Handling
+   -------------------
+
+   procedure Handle_Ping_Reply(Message : in Message_Record) with
+      Pre => Echo_Server.API.Is_Ping_Reply(Message)
+   is
+      Status           : Echo_Server.API.Status_Type;
+      Decode_Status    : Message_Status_Type;
+      Round_Trip_Time  : Ada.Real_Time.Time_Span;
+   begin
+      Echo_Server.API.Ping_Reply_Decode(Message, Status, Decode_Status);
+      Receive_Time := Ada.Real_Time.Clock;
+      Round_Trip_Time := Receive_Time - Send_Time;
+
+      if Decode_Status /= Success then
+         Ada.Text_IO.Put_Line("ERROR: Unable to decode a Ping_Reply message!");
+      elsif Status /= Echo_Server.API.Success then
+         Ada.Text_IO.Put_Line("ERROR: Echo server reported a ping failure!");
+      else
+         Ada.Text_IO.Put("+++ Reply #");
+         Request_IO.Put(Message.Request_ID);
+         Ada.Text_IO.Put(" (RTT = ");
+         Duration_IO.Put(Ada.Real_Time.To_Duration(Round_Trip_Time));
+         Ada.Text_IO.Put("s)");
+         Ada.Text_IO.New_Line;
+
+         delay 1.0;  -- Delay for a while so the human can read the above messages.
+         Request_Number := Request_Number + 1;
+
+         -- Send the next message!
+         Send_Time := Ada.Real_Time.Clock;
+         Outgoing_Message := Echo_Server.API.Ping_Request_Encode
+           (Sender_Address => Name_Resolver.Echo_Client,
+            Request_ID    => Request_Number);
+         Route_Message(Outgoing_Message);
+      end if;
+
+      -- Do math on time spent on message (possibly faster by saving till end?)
+      --Relative_Time     := Ada.Real_Time.Clock - Start_Time;
+      --Relative_Duration := Ada.Real_Time.To_Duration (Relative_Time);
+      --Total_Time := Total_Time + Ada.Real_Time.To_Duration (Relative_Time);
+
+      -- Print information about the ping
+      --Ada.Text_IO.Put ("+++ Ping ");
+      --Ada.Integer_Text_IO.Put (Item => i, Width => 0, Base => 10);
+
+      --Put (" | Request ID: " & Request_ID_Type'Image (Message.Request_ID));
+
+      --Ada.Text_IO.Put_Line (" | Received PINGED");
+      --Put ("Ping");
+      --Put (i'Image);
+      --Put (" Time Duration:   ");
+      --Put (Relative_Duration);
+      --New_Line;
+      -- Wait a bit.
+      -- delay(2.5);
+
+  end Handle_Ping_Reply;
+
+   -----------------------------------
+   -- Message Decoding and Dispatching
+   -----------------------------------
+
+   -- This procedure processes exactly one message at a time.
+   procedure Process(Message : in Message_Record) is
+   begin
+      if Echo_Server.API.Is_Ping_Reply(Message) then
+         Handle_Ping_Reply(Message);
+      else
+         -- An unknown message type has been received. What should be done about that?
+         null;
+      end if;
+   end Process;
+
+   ---------------
+   -- Message Loop
+   ---------------
+
+   task body Message_Loop is
+      Incoming_Message : Message_Record;
+   begin
+      Initialize;
+      loop
+         Message_Manager.Fetch_Message(Name_Resolver.Echo_Client.Module_ID, Incoming_Message);
+         Process(Incoming_Message);
+      end loop;
+   end Message_Loop;
+
+end Echo_Client.Messages;

--- a/samples/Echo_Alire/src/echo_client-messages.adb
+++ b/samples/Echo_Alire/src/echo_client-messages.adb
@@ -72,27 +72,6 @@ package body Echo_Client.Messages is
             Request_ID    => Request_Number);
          Route_Message(Outgoing_Message);
       end if;
-
-      -- Do math on time spent on message (possibly faster by saving till end?)
-      --Relative_Time     := Ada.Real_Time.Clock - Start_Time;
-      --Relative_Duration := Ada.Real_Time.To_Duration (Relative_Time);
-      --Total_Time := Total_Time + Ada.Real_Time.To_Duration (Relative_Time);
-
-      -- Print information about the ping
-      --Ada.Text_IO.Put ("+++ Ping ");
-      --Ada.Integer_Text_IO.Put (Item => i, Width => 0, Base => 10);
-
-      --Put (" | Request ID: " & Request_ID_Type'Image (Message.Request_ID));
-
-      --Ada.Text_IO.Put_Line (" | Received PINGED");
-      --Put ("Ping");
-      --Put (i'Image);
-      --Put (" Time Duration:   ");
-      --Put (Relative_Duration);
-      --New_Line;
-      -- Wait a bit.
-      -- delay(2.5);
-
   end Handle_Ping_Reply;
 
    -----------------------------------

--- a/samples/Echo_Alire/src/echo_client-messages.ads
+++ b/samples/Echo_Alire/src/echo_client-messages.ads
@@ -1,0 +1,16 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_client-messages.ads
+-- SUBJECT: Specification of a package that implements the main part of the module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with System;
+
+package Echo_Client.Messages is
+
+   task Message_Loop is
+      pragma Storage_Size(4 * 1024);
+      pragma Priority(System.Default_Priority);
+   end Message_Loop;
+
+end Echo_Client.Messages;

--- a/samples/Echo_Alire/src/echo_client.ads
+++ b/samples/Echo_Alire/src/echo_client.ads
@@ -1,0 +1,12 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_client.ads
+-- SUBJECT: Top level package of the echo client module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
+with Message_Manager;
+
+package Echo_Client is
+
+end Echo_Client;

--- a/samples/Echo_Alire/src/echo_server-api.adb
+++ b/samples/Echo_Alire/src/echo_server-api.adb
@@ -1,0 +1,89 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_server-api.adb
+-- SUBJECT: Body of a package that simplifies use of the module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with CubedOS.Lib.XDR;
+use  CubedOS.Lib;
+
+package body Echo_Server.API is
+   use type XDR.XDR_Unsigned;
+
+   function Ping_Request_Encode
+     (Sender_Address : Message_Address;
+      Request_ID    : Request_ID_Type;
+      Priority      : System.Priority := System.Default_Priority) return Message_Record
+   is
+      Message : constant Message_Record :=
+        Make_Empty_Message
+          (Sender_Address => Sender_Address,
+           Receiver_Address => Name_Resolver.Echo_Server,
+           Request_ID      => Request_ID,
+           Message_ID      => Message_Type'Pos(Ping_Request),
+           Priority        => Priority);
+   begin
+      return Message;
+   end Ping_Request_Encode;
+
+
+   function Ping_Reply_Encode
+     (Receiver_Address : Message_Address;
+      Request_ID : Request_ID_Type;
+      Status     : Status_Type;
+      Priority   : System.Priority := System.Default_Priority) return Message_Record
+   is
+      Message : Message_Record :=
+        Make_Empty_Message
+          (Sender_Address => Name_Resolver.Echo_Server,
+           Receiver_Address => Receiver_Address,
+           Request_ID      => Request_ID,
+           Message_ID      => Message_Type'Pos(Ping_Reply),
+           Priority        => Priority);
+
+      Position : Data_Index_Type;
+      Last     : Data_Index_Type;
+   begin
+      Position := 0;
+      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload, Position, Last);
+      Position := Last + 1;
+
+      Message.Size := Last + 1;
+      return Message;
+   end Ping_Reply_Encode;
+
+
+   procedure Ping_Request_Decode
+     (Message : in Message_Record;
+      Decode_Status : out Message_Status_Type)
+   is
+   begin
+      -- Decoding can never fail in this case because there are no message parameters.
+      Decode_Status := Success;
+   end Ping_Request_Decode;
+
+
+   procedure Ping_Reply_Decode
+     (Message : in Message_Record;
+      Status : out Status_Type;
+      Decode_Status : out Message_Status_Type)
+   is
+      Position  : Data_Index_Type;
+      Last      : Data_Index_Type;
+      Raw_Value : XDR.XDR_Unsigned;
+   begin
+      Position := 0;
+
+      XDR.Decode(Message.Payload, Position, Raw_Value, Last);
+      Position := Last + 1;
+
+      if Raw_Value > Status_Type'Pos(Status_Type'Last) then
+         Decode_Status := Malformed;
+      else
+         Status := Status_Type'Val(Raw_Value);
+         Decode_Status := Success;
+      end if;
+   end Ping_Reply_Decode;
+
+
+end Echo_Server.API;

--- a/samples/Echo_Alire/src/echo_server-api.ads
+++ b/samples/Echo_Alire/src/echo_server-api.ads
@@ -1,0 +1,60 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_server-api.ads
+-- SUBJECT: Specification of a package that simplifies use of the module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with Message_Manager; use Message_Manager;
+with Name_Resolver;
+with System;
+
+package Echo_Server.API is
+
+   -- Used to indicate the success or failure of the requested operation.
+   type Status_Type is (Success, Failure);
+
+   type Message_Type is (Ping_Request, Ping_Reply);
+
+   function Ping_Request_Encode
+     (Sender_Address : Message_Address;
+      Request_ID    : Request_ID_Type;
+      Priority      : System.Priority := System.Default_Priority) return Message_Record
+     with
+       Global => null;
+
+   function Ping_Reply_Encode
+     (Receiver_Address : Message_Address;
+      Request_ID : Request_ID_Type;
+      Status     : Status_Type;
+      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     with
+       Global => null;
+
+   function Is_Ping_Request(Message : Message_Record) return Boolean is
+     (Message.Receiver_Address = Name_Resolver.Echo_Server and Message.Message_ID = Message_Type'Pos(Ping_Request));
+
+   function Is_Ping_Reply(Message : Message_Record) return Boolean is
+     (Message.Sender_Address = Name_Resolver.Echo_Server and Message.Message_ID = Message_Type'Pos(Ping_Reply));
+
+   procedure Ping_Request_Decode
+     (Message : in Message_Record;
+      Decode_Status : out Message_Status_Type)
+     with
+       Global => null,
+       Pre => Is_Ping_Request(Message),
+       Depends => (Decode_Status => null, null => Message);
+       -- Depends => (Decode_Status => Message);
+       -- In this case, decoding can't fail because the message has no parameters.
+
+   procedure Ping_Reply_Decode
+     (Message : in Message_Record;
+      Status  : out Status_Type;
+      Decode_Status : out Message_Status_Type)
+     with
+       Global => null,
+       Pre => Is_Ping_Reply(Message),
+       Depends => (Status => null, Decode_Status => Message);
+       -- Depends => ((Status, Decode_Status) => Message);
+       -- In this case, Status is always "Success"; pinging the server never fails.
+
+end Echo_Server.API;

--- a/samples/Echo_Alire/src/echo_server-messages.adb
+++ b/samples/Echo_Alire/src/echo_server-messages.adb
@@ -1,0 +1,64 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_server-messages.adb
+-- SUBJECT: Body of a package that implements the main part of the module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--------------------------------------------------------------------------------
+with Echo_Server.API;
+with Name_Resolver;
+
+package body Echo_Server.Messages is
+   use Message_Manager;
+
+   -------------------
+   -- Message Handling
+   -------------------
+
+   procedure Handle_Ping_Request(Message : in Message_Record)
+     with
+       Pre => Echo_Server.API.Is_Ping_Request(Message)
+   is
+      Outgoing_Message : Message_Record;
+      Decode_Status    : Message_Status_Type;
+   begin
+      Echo_Server.API.Ping_Request_Decode(Message, Decode_Status);
+
+      -- Just ignore messages that don't decode properly (decoding Ping_Requests can't fail anyway).
+      if Decode_Status = Message_Manager.Success then
+         Outgoing_Message :=
+           Echo_Server.API.Ping_Reply_Encode
+             (Receiver_Address => Message.Sender_Address,
+              Request_ID      => Message.Request_ID,
+              Status          => Echo_Server.API.Success);  -- Ping is always successful.
+         Message_Manager.Route_Message(Outgoing_Message);
+      end if;
+   end Handle_Ping_Request;
+
+   -----------------------------------
+   -- Message Decoding and Dispatching
+   -----------------------------------
+
+   -- This procedure processes exactly one message.
+   procedure Process(Message : in Message_Record) is
+   begin
+      if Echo_Server.API.Is_Ping_Request(Message) then
+         Handle_Ping_Request(Message);
+      else
+         -- An unknown message type has been received. What should be done about that?
+         null;
+      end if;
+   end Process;
+
+   ---------------
+   -- Message Loop
+   ---------------
+
+   task body Message_Loop is
+      Incoming_Message : Message_Manager.Message_Record;
+   begin
+      loop
+         Message_Manager.Fetch_Message(Name_Resolver.Echo_Server.Module_ID, Incoming_Message);
+         Process(Incoming_Message);
+      end loop;
+   end Message_Loop;
+
+end Echo_Server.Messages;

--- a/samples/Echo_Alire/src/echo_server-messages.ads
+++ b/samples/Echo_Alire/src/echo_server-messages.ads
@@ -1,0 +1,16 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_server-messages.ads
+-- SUBJECT: Specification of a package that implements the main part of the module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with System;
+
+package Echo_Server.Messages is
+
+   task Message_Loop is
+      pragma Storage_Size(4 * 1024);
+      pragma Priority(System.Default_Priority);
+   end Message_Loop;
+
+end Echo_Server.Messages;

--- a/samples/Echo_Alire/src/echo_server.ads
+++ b/samples/Echo_Alire/src/echo_server.ads
@@ -1,0 +1,12 @@
+--------------------------------------------------------------------------------
+-- FILE   : echo_server.ads
+-- SUBJECT: Top level package of the echo server module.
+-- AUTHOR : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+pragma Warnings (Off, "unit ""Message_Manager"" is not referenced");
+with Message_Manager;
+
+package Echo_Server is
+   
+end Echo_Server;

--- a/samples/Echo_Alire/src/message_manager.ads
+++ b/samples/Echo_Alire/src/message_manager.ads
@@ -1,0 +1,15 @@
+--------------------------------------------------------------------------------
+-- FILE    : message_manager.adb
+-- SUBJECT : Package holding the mailboxes used by CubedOS message passing.
+-- AUTHOR  : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with CubedOS.Generic_Message_Manager;
+pragma Elaborate_All(CubedOS.Generic_Message_Manager);
+
+package Message_Manager is
+  new CubedOS.Generic_Message_Manager
+    (Domain_Number =>  1,
+     Module_Count  =>  2,
+     Mailbox_Size  =>  8,
+     Maximum_Message_Size => 512);

--- a/samples/Echo_Alire/src/name_resolver.ads
+++ b/samples/Echo_Alire/src/name_resolver.ads
@@ -1,0 +1,17 @@
+--------------------------------------------------------------------------------
+-- FILE    : name_resolver.ads
+-- SUBJECT : Specification holding Domain IDs and Module IDs
+-- AUTHOR  : (C) Copyright 2021 by Vermont Technical College
+--
+--------------------------------------------------------------------------------
+with Message_Manager; use Message_Manager;
+
+package Name_Resolver is
+
+    -- Core Modules
+
+    -- Application-Specific Modules
+    Echo_Client             : constant Message_Address := (1,1);
+    Echo_Server             : constant Message_Address := (1,2);
+
+end Name_Resolver;


### PR DESCRIPTION
Using the [Echo](https://github.com/cubesatlab/cubedos/tree/master/samples/Echo) program as a base, I've created an [executable crate](https://alire.ada.dev/docs/#introduction:~:text=Creating%20a%20new%20crate) to demonstrate how to build and run a CubedOS application using [Alire](https://alire.ada.dev/). 

Running the sample program is as simple as downloading Alire and running `alr run` in the project directory.  It is now possible to pull in Alire packages using `alr with <package_name>`

The directory structure is slightly different than the original Echo project.  Ada Bodies and Ada Specification files are now in `src/`.  