### PR TITLE
Msg objects

### DIFF
--- a/src/check/main_message_manager.adb
+++ b/src/check/main_message_manager.adb
@@ -6,11 +6,13 @@ use Message_Manager;
 
 procedure Main_Message_Manager is
 
-   Message, Message_2, Message_3, Message_4, Message_5, Message_6 : Message_Manager.Message_Record;
+   Message, Message_2, Message_3, Message_4, Message_5, Message_6 : Message_Manager.Msg_Owner
+     := new Message_Record'(Make_Empty_Message((1, 1), (1, 1), 0, 0));
    Message_ID : constant Message_Manager.Message_ID_Type:= 1;
    Message_ID_2 : constant Message_Manager.Message_ID_Type:= 2;
    Message_Status : Message_Manager.Status_Type;
    X : Integer := 1;
+   Mailbox_1, Mailbox_2 : Message_Manager.Module_Mailbox;
 
    procedure Fetch is
       Y : Integer := 1;
@@ -18,7 +20,7 @@ procedure Main_Message_Manager is
       Put_Line("+++++ FETCHING MESSAGES FOR RECIEVER ID = 1 +++++");
       New_Line;
       while Y < 9 loop
-         Fetch_Message(Module  => Message.Receiver_Address.Module_ID, Message => Message);
+         Message_Manager.Read_Next(Mailbox_1, Message);
          Put_Line("Message " & Integer'Image(Y) & " fetched ");
          Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message.Sender_Address.Module_ID));
          Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message.Receiver_Address.Module_ID));
@@ -38,7 +40,7 @@ procedure Main_Message_Manager is
       Put_Line("+++++ FETCHING MESSAGES FOR RECIEVER ID = 2 +++++");
       New_Line;
       while Y < 9 loop
-         Fetch_Message(Module  => Message_5.Receiver_Address.Module_ID, Message => Message_5);
+         Message_Manager.Read_Next(Mailbox_2, Message_5);
          Put_Line("Message " & Integer'Image(Y) & " fetched ");
          Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_5.Sender_Address.Module_ID));
          Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver_Address.Module_ID));
@@ -53,6 +55,9 @@ procedure Main_Message_Manager is
    end Fetch_2;
 
 begin
+   -- Register receiving mailboxes
+   Message_Manager.Register_Module(1, 8, Mailbox_1);
+   Message_Manager.Register_Module(2, 8, Mailbox_2);
 
    -- Test Get_Next_Request_ID
    Put_Line("Testing Get_Next_Request_ID");
@@ -72,33 +77,33 @@ begin
    New_Line(2);
 
    -- Test Make_Empty_Message
-   Message_3 := Make_Empty_Message
+   Message_3 := new Message_Record'(Make_Empty_Message
      (Sender_Address   => (0, 2),
       Receiver_Address => (0, 1),
       Request_ID       => 4,
       Message_ID       => Message_ID,
-      Priority         => 2);
+      Priority         => 2));
 
-   Message_4 := Make_Empty_Message
+   Message_4 := new Message_Record'(Make_Empty_Message
      (Sender_Address   => (1, 1),
       Receiver_Address => (1, 2),
       Request_ID       => 8,
       Message_ID       => Message_ID_2,
-      Priority         => 5);
+      Priority         => 5));
 
-   Message_5 := Make_Empty_Message
+   Message_5 := new Message_Record'(Make_Empty_Message
      (Sender_Address   => (2, 2),
       Receiver_Address => (1, 2),
       Request_ID       => 1,
       Message_ID       => 1,
-      Priority         => 1);
+      Priority         => 1));
 
-   Message_6 := Make_Empty_Message
+   Message_6 := new Message_Record'(Make_Empty_Message
      (Sender_Address   => (1, 2),
       Receiver_Address => (1, 2),
       Request_ID       => 1,
       Message_ID       => Message_ID_2,
-      Priority         => 4);
+      Priority         => 4));
 
 
    -- 20 messages should be attempted to be sent, only first eight should be sent
@@ -107,7 +112,7 @@ begin
    while X < 40 loop
       -- Ensure the Make_Empty_Message works properly
       if X = 12 or X = 31 then
-         Route_Message(Message => Message_3, Status => Message_Status);
+         Route_Message(Message => Message_3.all, Status => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
          Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_3.Sender_Address.Module_ID));
@@ -118,7 +123,7 @@ begin
          X := X + 1;
 
       elsif X = 15 or X = 22 then
-         Route_Message(Message => Message_4, Status  => Message_Status);
+         Route_Message(Message => Message_4.all, Status  => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
          Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_4.Sender_Address.Module_ID));
@@ -129,7 +134,7 @@ begin
          X := X + 1;
 
       elsif X = 11 or X = 28 then
-         Route_Message(Message => Message_5, Status  => Message_Status);
+         Route_Message(Message => Message_5.all, Status  => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
          Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_5.Sender_Address.Module_ID));
@@ -142,7 +147,7 @@ begin
 
       elsif X = 4 or X = 23 then
          -- Test Route_Message without status parameter
-         Route_Message(Message => Message_2);
+         Route_Message(Message => Message_2.all);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
          Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_2.Sender_Address.Module_ID));
@@ -155,7 +160,7 @@ begin
       else
          -- Testing Route_Message with Status parameter
          if X < 22 then
-            Route_Message(Message => Message, Status => Message_Status);
+            Route_Message(Message => Message.all, Status => Message_Status);
             Put_Line("Message" & Integer'Image(X) & " routed");
             Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
             Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message.Sender_Address.Module_ID));
@@ -167,7 +172,7 @@ begin
          end if;
 
          if X > 20 then
-            Route_Message(Message => Message_6, Status => Message_Status);
+            Route_Message(Message => Message_6.all, Status => Message_Status);
             Put_Line("Message" & Integer'Image(X) & " routed");
             Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
             Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_6.Sender_Address.Module_ID));

--- a/src/check/message_manager.ads
+++ b/src/check/message_manager.ads
@@ -15,5 +15,4 @@ package Message_Manager is
   new CubedOS.Generic_Message_Manager
     (Domain_Number =>  1,
      Module_Count  => 16,
-     Mailbox_Size  =>  8,
      Maximum_Message_Size => 1024);

--- a/src/modules/cubedos-file_server-messages.ads
+++ b/src/modules/cubedos-file_server-messages.ads
@@ -22,5 +22,7 @@ package CubedOS.File_Server.Messages is
       Intentional,
       "multiple tasks might queue on protected entry",
       "Every module has a unique ID");
+private
+   Mailbox : Message_Manager.Module_Mailbox;
 
 end CubedOS.File_Server.Messages;

--- a/src/modules/cubedos-generic_message_manager.adb
+++ b/src/modules/cubedos-generic_message_manager.adb
@@ -4,59 +4,67 @@
 -- AUTHOR : (C) Copyright 2022 by Vermont Technical College
 --
 --------------------------------------------------------------------------------
-pragma SPARK_Mode(On);
+pragma SPARK_Mode (On);
 with Ada.Unchecked_Deallocation;
 
 -- with Name_Resolver;
 
-
-
-package body CubedOS.Generic_Message_Manager
-  with Refined_State => (Mailboxes => Message_Storage, Request_ID_Generator => Request_ID_Gen)
+package body CubedOS.Generic_Message_Manager with
+   Refined_State => (Mailboxes => Message_Storage,
+    Mailbox_Init_Tracker => Inited, Request_ID_Generator => Request_ID_Gen)
 is
 
-   procedure Free is new Ada.Unchecked_Deallocation (Object => Message_Record, Name => Msg_Owner);
+   procedure Free is new Ada.Unchecked_Deallocation
+     (Object => Message_Record, Name => Msg_Owner);
 
    -- A protected object for generating request ID values.
    protected Request_ID_Gen is
-      procedure Generate_Next_ID(Request_ID : out Request_ID_Type);
+      procedure Generate_Next_ID (Request_ID : out Request_ID_Type);
    private
       Next_Request_ID : Request_ID_Type := 1;
    end Request_ID_Gen;
 
    type Msg_Ptr_Array_Ptr is access Message_Ptr_Array;
 
-  -- A protected type for holding messages.
-   protected type Mailbox is new Module_Mailbox
+   -- A protected type for holding messages.
+   protected type Sync_Mailbox is
 
-      -- Send the indicated message. This procedure returns at once without waiting for the
+      -- Deposit the given message into THIS mailbox. This procedure returns at once without waiting for the
       -- message to be received. If the mailbox is full the returned status indicates this.
-      procedure Send(Message : not null access constant Message_Record; Status : out Status_Type);
+      procedure Send
+        (Message : in out Msg_Owner; Status : out Status_Type) with
+         Pre => Module_Ready (Message.Receiver_Address.Module_ID);
 
       -- Send the indicated message. This procedure returns at once without waiting for the
       -- message to be received. If the mailbox is full the message is lost.
-      procedure Unchecked_Send(Message : not null access constant Message_Record);
+      procedure Unchecked_Send (Message : in out Msg_Owner) with
+         Pre => Module_Ready (Message.Receiver_Address.Module_ID);
 
       -- Returns the number of messages in the mailbox.
       function Message_Count return Message_Count_Type;
 
       -- Receive a message. This entry waits indefinitely for a message to be available.
-      entry Receive(Message : out Message_Record);
+      entry Receive (Message : out Msg_Owner) with
+         Pre => Module_Ready (Message.Receiver_Address.Module_ID);
 
       -- Change the array used to store messages.
-      procedure Set_Msg_Array(Arr : Msg_Ptr_Array_Ptr)
-        with Pre => Message_Count = 0;
+      procedure Set_Msg_Array (Arr : in out Msg_Ptr_Array_Ptr);
 
    private
-      Messages : Msg_Ptr_Array_Ptr;
-      Count    : Message_Count_Type := 0;
-      Next_In  : Message_Index_Type := 1;
-      Next_Out : Message_Index_Type := 1;
-      Message_Waiting : Boolean := False;
-   end Mailbox;
+      Messages        : Msg_Ptr_Array_Ptr;
+      Count           : Message_Count_Type := 0;
+      Next_In         : Message_Index_Type := 1;
+      Next_Out        : Message_Index_Type := 1;
+      Mailbox_Size    : Positive           := 1;
+      Message_Waiting : Boolean            := False;
+   end Sync_Mailbox;
 
    -- One mailbox for each module.
-   Message_Storage : array(Module_ID_Type) of Mailbox;
+   Message_Storage : array (Module_ID_Type) of Sync_Mailbox;
+   Inited          : array (Module_ID_Type) of Boolean := (others => False);
+
+   function Module_Ready (Module_ID : Module_ID_Type) return Boolean is
+     (Inited (Module_ID));
 
    ------------------
    -- Implementations
@@ -64,60 +72,58 @@ is
 
    protected body Request_ID_Gen is
 
-      procedure Generate_Next_ID(Request_ID : out Request_ID_Type) is
+      procedure Generate_Next_ID (Request_ID : out Request_ID_Type) is
       begin
-         Request_ID := Next_Request_ID;
+         Request_ID      := Next_Request_ID;
          Next_Request_ID := Next_Request_ID + 1;
       end Generate_Next_ID;
 
    end Request_ID_Gen;
 
+   protected body Sync_Mailbox is
 
-   protected body Mailbox is
-
-      procedure Send(Message : not null access constant Message_Record; Status : out Status_Type) is
+      procedure Send (Message : in out Msg_Owner; Status : out Status_Type) is
       begin
          if Count = Mailbox_Size then
             Status := Mailbox_Full;
          else
-            Messages(Next_In) := new Message_Record'(Message.all);
+            Messages (Next_In) := Message;
+            Message            := null;
             if Next_In = Mailbox_Size then
                Next_In := 1;
             else
                Next_In := Next_In + 1;
             end if;
-            Count := Count + 1;
+            Count           := Count + 1;
             Message_Waiting := True;
-            Status := Accepted;
+            Status          := Accepted;
          end if;
       end Send;
 
-
-      procedure Unchecked_Send(Message : not null access constant Message_Record) is
+      procedure Unchecked_Send (Message : in out Msg_Owner) is
       begin
          if Count /= Mailbox_Size then
-            Messages(Next_In) := new Message_Record'(Message.all);
+            Messages (Next_In) := Message;
+            Message            := null;
             if Next_In = Mailbox_Size then
                Next_In := 1;
             else
                Next_In := Next_In + 1;
             end if;
-            Count := Count + 1;
+            Count           := Count + 1;
             Message_Waiting := True;
          end if;
       end Unchecked_Send;
-
 
       function Message_Count return Message_Count_Type is
       begin
          return Count;
       end Message_Count;
 
-
-      entry Receive(Message : out Message_Record) when Message_Waiting is
+      entry Receive (Message : out Msg_Owner) when Message_Waiting is
       begin
-         Message := Messages(Next_Out).all;
-         Free (Messages(Next_Out));
+         Message             := Messages (Next_Out);
+         Messages (Next_Out) := null;
          if Next_Out = Mailbox_Size then
             Next_Out := 1;
          else
@@ -129,92 +135,136 @@ is
          end if;
       end Receive;
 
-   end Mailbox;
+      procedure Set_Msg_Array (Arr : in out Msg_Ptr_Array_Ptr) is
+      begin
+         Mailbox_Size := Arr'Length;
+         Messages     := Arr;
+         Arr          := null;
+      end Set_Msg_Array;
 
+   end Sync_Mailbox;
 
    function Make_Empty_Message
-     (Sender_Address   : Message_Address;
-      Receiver_Address : Message_Address;
-      Request_ID : Request_ID_Type;
-      Message_ID : Message_ID_Type;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+     (Sender_Address : Message_Address; Receiver_Address : Message_Address;
+      Request_ID     : Request_ID_Type; Message_ID : Message_ID_Type;
+      Priority       : System.Priority := System.Default_Priority)
+      return Message_Record
    is
       Message : Message_Record;
    begin
-      Message.Sender_Address := Sender_Address;
-      Message.Receiver_Address   := Receiver_Address;
-      Message.Request_ID := Request_ID;
-      Message.Message_ID := Message_ID;
-      Message.Priority   := Priority;
-      Message.Size       := 0;
-      Message.Payload := (others => 0);
+      Message.Sender_Address   := Sender_Address;
+      Message.Receiver_Address := Receiver_Address;
+      Message.Request_ID       := Request_ID;
+      Message.Message_ID       := Message_ID;
+      Message.Priority         := Priority;
+      Message.Size             := 0;
+      Message.Payload          := (others => 0);
       return Message;
    end Make_Empty_Message;
 
-
    function Stringify_Message (Message : in Message_Record) return String is
-      Sender_Domain_String : constant String := Domain_ID_Type'Image(Message.Sender_Address.Domain_ID);
-      Sender_Module_String : constant String := Module_ID_Type'Image(Message.Sender_Address.Module_ID);
-      Receiver_Domain_String : constant String := Module_ID_Type'Image(Message.Receiver_Address.Domain_ID);
-      Receiver_Module_String : constant String := Module_ID_Type'Image(Message.Receiver_Address.Module_ID);
-      Request_ID_String : constant String := Request_ID_Type'Image(Message.Request_ID);
-      Message_ID_String : constant String := Message_ID_Type'Image(Message.Message_ID);
-      Message_Image     : constant String := Sender_Domain_String & "!" & Sender_Module_String & "!" &
-                                             Receiver_Domain_String & "!" &  Receiver_Module_String & "!" &
-                                             Request_ID_String & "!" & Message_ID_String & "!";
-    begin
-      return Message_Image;
-    end Stringify_Message;
-
-
-   procedure Get_Next_Request_ID(Request_ID : out Request_ID_Type) is
+      Sender_Domain_String : constant String :=
+        Domain_ID_Type'Image (Message.Sender_Address.Domain_ID);
+      Sender_Module_String : constant String :=
+        Module_ID_Type'Image (Message.Sender_Address.Module_ID);
+      Receiver_Domain_String : constant String :=
+        Module_ID_Type'Image (Message.Receiver_Address.Domain_ID);
+      Receiver_Module_String : constant String :=
+        Module_ID_Type'Image (Message.Receiver_Address.Module_ID);
+      Request_ID_String : constant String :=
+        Request_ID_Type'Image (Message.Request_ID);
+      Message_ID_String : constant String :=
+        Message_ID_Type'Image (Message.Message_ID);
+      Message_Image : constant String :=
+        Sender_Domain_String & "!" & Sender_Module_String & "!" &
+        Receiver_Domain_String & "!" & Receiver_Module_String & "!" &
+        Request_ID_String & "!" & Message_ID_String & "!";
    begin
-      Request_ID_Gen.Generate_Next_ID(Request_ID);
+      return Message_Image;
+   end Stringify_Message;
+
+   procedure Get_Next_Request_ID (Request_ID : out Request_ID_Type) is
+   begin
+      Request_ID_Gen.Generate_Next_ID (Request_ID);
    end Get_Next_Request_ID;
 
-
-   procedure Route_Message(Message : in Message_Record; Status : out Status_Type) is
-      Ptr : Msg_Owner := new Message_Record'(Message);
-   begin
-      -- For now, let's ignore the domain and just use the receiver Module_ID only.
-      Message_Storage(Message.Receiver_Address.Module_ID).Send(Ptr, Status);
-      Free (Ptr);
-   end Route_Message;
-
-
-   procedure Route_Message(Message : in Message_Record) is
-      Ptr : Msg_Owner := new Message_Record'(Message);
-   begin
-      if Message.Receiver_Address.Domain_ID /= Domain_ID then
-        -- Circular Dependency with Name_Resolver so resorting to hardcoding
-        -- Message_Storage(Name_Resolver.Network_Server.Module_ID).Unchecked_Send(Message);
-        Message_Storage(2).Unchecked_Send(Ptr);
-      else
-        Message_Storage(Message.Receiver_Address.Module_ID).Unchecked_Send(Ptr);
-      end if;
-      Free (Ptr);
-   end Route_Message;
-
-   procedure Fetch_Message(Module : in Module_ID_Type; Message : out Message_Record) is
-   begin
-      Message_Storage(Module).Receive(Message);
-   end Fetch_Message;
-
-   procedure Register_Module(Module_ID : in Module_ID_Type;
-                             Msg_Queue_Size : in Positive;
-                             Module_Mailbox : out access constant Module_Mailbox;
-                            )
+   procedure Route_Message
+     (Message : in out Msg_Owner; Status : out Status_Type)
    is
    begin
+      -- For now, let's ignore the domain and just use the receiver Module_ID only.
+      Message_Storage (Message.Receiver_Address.Module_ID).Send
+        (Message, Status);
+   end Route_Message;
+
+   procedure Route_Message (Message : in out Msg_Owner) is
+   begin
+      if Message.Receiver_Address.Domain_ID /= Domain_ID then
+         -- Circular Dependency with Name_Resolver so resorting to hardcoding
+         -- Message_Storage(Name_Resolver.Network_Server.Module_ID).Unchecked_Send(Message);
+         Message_Storage (2).Unchecked_Send (Message);
+      else
+         Message_Storage (Message.Receiver_Address.Module_ID).Unchecked_Send
+           (Message);
+      end if;
+   end Route_Message;
+
+   procedure Route_Message (Message : in Message_Record) is
+      Ptr : Msg_Owner := new Message_Record'(Message);
+   begin
+      Route_Message (Ptr);
+   end Route_Message;
+
+   procedure Route_Message
+     (Message : in Message_Record; Status : out Status_Type)
+   is
+      Ptr : Msg_Owner := new Message_Record'(Message);
+   begin
+      Route_Message (Ptr, Status);
+   end Route_Message;
+
+   procedure Fetch_Message
+     (Module : in Module_ID_Type; Message : out Msg_Owner)
+   is
+   begin
+      Message_Storage (Module).Receive (Message);
+   end Fetch_Message;
+
+   procedure Send_Message (Box : Module_Mailbox; Msg : Message_Record) is
+      Ptr : Msg_Owner := new Message_Record'(Msg);
+   begin
+      Route_Message (Ptr);
+   end Send_Message;
+
+   procedure Send_Message
+     (Box : Module_Mailbox; Msg : Message_Record; Status : out Status_Type)
+   is
+      Ptr : Msg_Owner := new Message_Record'(Msg);
+   begin
+      Route_Message (Ptr, Status);
+   end Send_Message;
+
+   procedure Read_Next (Box : Module_Mailbox; Msg : out Msg_Owner) is
+   begin
+      Fetch_Message (Box.Address.Module_ID, Msg);
+   end Read_Next;
+
+   procedure Register_Module
+     (Module_ID : in     Module_ID_Type; Msg_Queue_Size : in Positive;
+      Mailbox   :    out Module_Mailbox)
+   is
+      Arr : Msg_Ptr_Array_Ptr := new Message_Ptr_Array (1 .. Msg_Queue_Size);
+   begin
       -- Create a new mailbox for the ID
-      Message_Storage(Module_ID).Set_Msg
+      Message_Storage (Module_ID).Set_Msg_Array (Arr);
+      Mailbox            := (Address => (Domain_ID, Module_ID));
+      Inited (Module_ID) := True;
    end Register_Module;
 
-
-   procedure Get_Message_Counts(Count_Array : out Message_Count_Array) is
+   procedure Get_Message_Counts (Count_Array : out Message_Count_Array) is
    begin
       for I in Module_ID_Type loop
-         Count_Array(I) := Message_Storage(I).Message_Count;
+         Count_Array (I) := Message_Storage (I).Message_Count;
       end loop;
    end Get_Message_Counts;
 

--- a/src/modules/cubedos-generic_message_manager.ads
+++ b/src/modules/cubedos-generic_message_manager.ads
@@ -16,12 +16,11 @@ use  CubedOS.Lib.XDR;
 generic
    Domain_Number : Positive;  -- The domain ID of this message manager.
    Module_Count  : Positive;  -- Number of modules in the system.
-   Mailbox_Size  : Positive;  -- Maximum number of pending messages in a mailbox.
    Maximum_Message_Size : Positive;  -- Maximum size of each message payload.
 package CubedOS.Generic_Message_Manager
   with
-    Abstract_State => ((Mailboxes with External), (Request_ID_Generator with External)),
-    Initializes => (Mailboxes, Request_ID_Generator)
+    Abstract_State => ((Mailboxes with External), Mailbox_Init_Tracker, (Request_ID_Generator with External)),
+    Initializes => (Mailboxes, Request_ID_Generator, Mailbox_Init_Tracker)
 is
    -- Definition of domain ID numbers. Domain #0 is special; it means the "current" domain.
    -- There is a limit to the number of domains that can be used. Make this a generic parameter?
@@ -111,41 +110,55 @@ is
    type Status_Type is (Accepted, Mailbox_Full);                          -- Mailbox access.
    type Message_Status_Type is (Success, Malformed, Insufficient_Space);  -- Message decoding.
 
-   -- Send the indicated message to the right mailbox. This might cross domains. This procedure
-   -- returns at once with a status of Accepted if the message was definitely delivered. A status
-   -- of Mailbox_Full indicates that delivery did not occur.
-   procedure Route_Message(Message : in Message_Record; Status : out Status_Type)
-     with Global => (In_Out => Mailboxes);
-
-   -- Send the indicated message to the right mailbox. This might cross domains. This procedure
-   -- returns at once. If the message could not be delivered it is lost with no indication.
-   procedure Route_Message(Message : in Message_Record)
-     with Global => (In_Out => Mailboxes);
-
    -- Retrieves a message from the indicated mailbox. May block indefinitely.
-   procedure Fetch_Message(Module : in Module_ID_Type; Message : out Message_Record)
+   procedure Fetch_Message(Module : in Module_ID_Type; Message : out Msg_Owner)
      with Global => (In_Out => Mailboxes);
 
-   type Module_Mailbox is protected interface;
+   -- True if the module is ready to receive mail.
+   function Module_Ready(Module_ID : Module_ID_Type) return Boolean
+     with Global => (Input => Mailbox_Init_Tracker);
 
-   procedure Send_Message(Box : access constant Module_Mailbox; Msg : Msg_Owner; Dest_Module : Module_ID_Type; Dest_Domain : Domain_ID_Type) is abstract;
 
-   procedure Receive(Box : access constant Module_Mailbox; Msg : Msg_Owner) is abstract;
+   -- A mailbox used by modules to send and receive messages.
+   -- This is the only way to receive messages sent to a module
+   -- and the only intended way to send messages from it.
+   -- Modules should keep their instance of this object invisible
+   -- to outside modules.
+   type Module_Mailbox is limited private;
+
+   -- Sends the given message to the given address from this mailbox's address.
+   -- Returns immediately.
+   procedure Send_Message(Box : Module_Mailbox; Msg : Message_Record)
+     with Global => (In_Out => Mailboxes),
+     Depends => (Mailboxes => +(Box, Msg));
+
+   -- Sends the given message to the given address from this mailbox's address.
+   -- Returns immediately with the status of the operation's result.
+   procedure Send_Message(Box : Module_Mailbox; Msg : Message_Record; Status : out Status_Type)
+     with Global => (In_Out => Mailboxes);
+
+   -- Reads the next message, removing it from the message queue.
+   -- Blocks until a message is available.
+   procedure Read_Next(Box : Module_Mailbox; Msg : out Msg_Owner);
 
    -- Register a module with the mail system.
    -- Gets an observer for that module's mailbox.
    procedure Register_Module(Module_ID : in Module_ID_Type;
                              Msg_Queue_Size : in Positive;
-                             Mailbox : access constant Module_Mailbox'Class
-                            )
-     with Global => (In_Out => Mailboxes);
+                             Mailbox : out Module_Mailbox)
+     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
+       Depends => (Mailboxes => +(Msg_Queue_Size, Module_ID),
+                   Mailbox_Init_Tracker => +(Module_ID),
+                   Mailbox => Module_ID),
+       Pre => Module_Ready(Module_ID) = False,
+       Post => Module_Ready(Module_ID) = True;
 
 
    -- Definition of the array type used to hold messages in a mailbox. This needs to be here
    -- rather than in the body because Message_Count_Type is used below.
-   subtype Message_Index_Type is Positive range 1 .. Mailbox_Size;
-   subtype Message_Count_Type is Natural range 0 .. Mailbox_Size;
-   type Message_Ptr_Array is array(Message_Index_Type) of Msg_Owner;
+   subtype Message_Index_Type is Positive;
+   subtype Message_Count_Type is Natural;
+   type Message_Ptr_Array is array(Positive range <>) of Msg_Owner;
 
    type Message_Count_Array is array(Module_ID_Type) of Message_Count_Type;
 
@@ -154,6 +167,39 @@ is
    -- the counts are being gathered. This procedure is intended to be used for software
    -- telemetry and debugging.
    procedure Get_Message_Counts(Count_Array : out Message_Count_Array)
-     with Global => (In_Out => Mailboxes);
+     with Global => (In_Out => Mailboxes, Input => Mailbox_Init_Tracker),
+       Pre => (for all I in Module_ID_Type => Module_Ready(I));
+
+
+   -- Send the indicated message to the right mailbox. This might cross domains. This procedure
+   -- returns at once with a status of Accepted if the message was definitely delivered. A status
+   -- of Mailbox_Full indicates that delivery did not occur.
+   --
+   -- Depreciated: Use Mailboxes to send messages
+   procedure Route_Message(Message : in out Msg_Owner; Status : out Status_Type)
+     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
+       Pre => (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID));
+
+   -- Send the indicated message to the right mailbox. This might cross domains. This procedure
+   -- returns at once. If the message could not be delivered it is lost with no indication.
+   --
+   -- Depreciated: Use Mailboxes to send messages
+   procedure Route_Message(Message : in out Msg_Owner)
+     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
+       Pre => (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID));
+
+   procedure Route_Message(Message : in Message_Record)
+     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
+     Pre => (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID));
+   procedure Route_Message(Message : in Message_Record; Status : out Status_Type)
+     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
+       Pre => (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID));
+
+private
+
+      type Module_Mailbox is
+      record
+         Address : Message_Address;
+      end record;
 
 end CubedOS.Generic_Message_Manager;

--- a/src/modules/cubedos-interpreter-messages.adb
+++ b/src/modules/cubedos-interpreter-messages.adb
@@ -77,14 +77,16 @@ package body CubedOS.Interpreter.Messages is
    ---------------
 
    task body Message_Loop is
-      Incoming_Message : Message_Manager.Message_Record;
+      Incoming_Message : Message_Manager.Msg_Owner;
    begin
       Initialize;
 
       loop
          Message_Manager.Fetch_Message(Name_Resolver.Interpreter.Module_ID, Incoming_Message);
-         Process(Incoming_Message);
+         Process(Incoming_Message.all);
       end loop;
    end Message_Loop;
 
+begin
+      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
 end CubedOS.Interpreter.Messages;

--- a/src/modules/cubedos-interpreter-messages.ads
+++ b/src/modules/cubedos-interpreter-messages.ads
@@ -15,4 +15,6 @@ package CubedOS.Interpreter.Messages is
       pragma Priority(System.Default_Priority);
    end Message_Loop;
 
+private
+   Mailbox : Message_Manager.Module_Mailbox;
 end CubedOS.Interpreter.Messages;

--- a/src/modules/cubedos-log_server-api.adb
+++ b/src/modules/cubedos-log_server-api.adb
@@ -20,8 +20,9 @@ package body CubedOS.Log_Server.API is
       Log_Level      : in Log_Level_Type;
       Text           : in String)
    is
+      Ptr : Msg_Owner := new Message_Record'(Log_Text_Encode(Sender_Address, 0, Log_Level, Text));
    begin
-      Message_Manager.Route_Message(Log_Text_Encode(Sender_Address, 0, Log_Level, Text));
+      Message_Manager.Route_Message(Ptr);
    end Log_Message;
 
 

--- a/src/modules/cubedos-log_server-messages.adb
+++ b/src/modules/cubedos-log_server-messages.adb
@@ -61,12 +61,14 @@ package body CubedOS.Log_Server.Messages is
    ---------------
 
    task body Message_Loop is
-      Incoming_Message : Message_Manager.Message_Record;
+      Incoming_Message : Message_Manager.Msg_Owner;
    begin
       loop
          Message_Manager.Fetch_Message(Name_Resolver.Log_Server.Module_ID, Incoming_Message);
-         Process(Incoming_Message);
+         Process(Incoming_Message.all);
       end loop;
    end Message_Loop;
 
+begin
+      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
 end CubedOS.Log_Server.Messages;

--- a/src/modules/cubedos-log_server-messages.ads
+++ b/src/modules/cubedos-log_server-messages.ads
@@ -20,4 +20,7 @@ package CubedOS.Log_Server.Messages is
       pragma Priority(System.Default_Priority);
    end Message_Loop;
 
+private
+   Mailbox : Message_Manager.Module_Mailbox;
+
 end CubedOS.Log_Server.Messages;

--- a/src/modules/cubedos-publish_subscribe_server-messages.ads
+++ b/src/modules/cubedos-publish_subscribe_server-messages.ads
@@ -16,12 +16,12 @@ with System;
 
 package CubedOS.Publish_Subscribe_Server.Messages
   with
-    Abstract_State => Database,
+    Abstract_State => (Database, Own_Mailbox),
     Initializes => Database
 is
 
    task type Message_Loop
-     with Global => (In_Out => (Database, Message_Manager.Mailboxes)),
+     with Global => (In_Out => (Database, Own_Mailbox)),
         Priority => System.Default_Priority
    is
       -- pragma Storage_Size(4 * 1024);

--- a/src/modules/cubedos-time_server-messages.ads
+++ b/src/modules/cubedos-time_server-messages.ads
@@ -14,16 +14,17 @@ with Message_Manager;
 
 package CubedOS.Time_Server.Messages
   with
-    Abstract_State => (Tick_Database with External),
-    Initializes => (Message_Loop, Tick_Database)
+    Abstract_State => ((Tick_Database with External), Own_Mailbox),
+    Initializes => (Message_Loop, Tick_Database, Own_Mailbox)
 is
 
    task Message_Loop
      with
-       Global => (Input => Ada.Real_Time.Clock_Time, In_Out => (Tick_Database, Message_Manager.Mailboxes))
+       Global => (Input => Ada.Real_Time.Clock_Time, In_Out => (Tick_Database, Own_Mailbox))
    is
       -- pragma Storage_Size(4 * 1024);
       pragma Priority(System.Default_Priority);
    end Message_Loop;
+
 
 end CubedOS.Time_Server.Messages;

--- a/src/modules/cubedos-transport_udp-messages.adb
+++ b/src/modules/cubedos-transport_udp-messages.adb
@@ -51,6 +51,7 @@ package body CubedOS.Transport_UDP.Messages is
       Data          : Ada.Streams.Stream_Element_Array (0 .. (Ada.Streams.Stream_Element_Offset(Message_Manager.Data_Index_Type'Last + 6)));
       Last          : Ada.Streams.Stream_Element_Offset;
       Message : Message_Manager.Message_Record;
+      Msg_Ptr : Message_Manager.Msg_Owner;
    begin
       Create_Socket (Server, Family_Inet, Socket_Datagram);
       Set_Socket_Option (Server, Socket_Level, (Reuse_Address, True));
@@ -65,7 +66,8 @@ package body CubedOS.Transport_UDP.Messages is
             if Message.Sender_Address.Domain_ID = Message_Manager.Domain_ID then
                Ada.Text_IO.Put_Line ("This message was sent from this domain! Dropping Message");
             else
-               Message_Manager.Route_Message(Message);
+               Msg_Ptr := new Message_Manager.Message_Record'(Message);
+               Message_Manager.Route_Message(Msg_Ptr);
             end if;
          exception
             when E : others =>
@@ -120,11 +122,11 @@ package body CubedOS.Transport_UDP.Messages is
    end Network_Loop;
 
    task body Message_Loop is
-      Incoming_Message : Message_Manager.Message_Record;
+      Incoming_Message : Message_Manager.Msg_Owner;
    begin
       loop
          Message_Manager.Fetch_Message(Name_Resolver.Network_Server, Incoming_Message);
-         Process(Incoming_Message);
+         Process(Incoming_Message.all);
       end loop;
    end Message_Loop;
 


### PR DESCRIPTION
Add Mailboxes

Add procedure to Message_Manager for module's to register themselves.
This procedure supplies them with a Module_Mailbox with several capabilities:
	- The only way to read the module's messages is with one
	of these boxes.
	- The only (expected) way for modules to send messages is
	by using a mailbox. The mailbox will ensure the message is
	sent from the correct address.
Additionally, Messages are now passed around with access types
and mailboxes have a queue size determined per module.

I changed as many of the modules as I could to use Mailboxes. Transport modules will require further consideration because they receive messages from outside the domain and similarly can't register mailboxes for them to be "sent" from. Perhaps Transport Modules should be a special component, different than modules? Maybe Modules and Transport Modules should implement different predefined interfaces? For now, I will leave the depreciated Route_Message functions publicly visible and mark them depreciated.

The tests pass but note that the SPARK analysis isn't complete. I'm not all the way though the refactor, just marking a milestone here.