### PR TITLE
Per Message Payload Size

### DIFF
--- a/src/check/main_message_manager.adb
+++ b/src/check/main_message_manager.adb
@@ -7,7 +7,7 @@ use Message_Manager;
 procedure Main_Message_Manager is
 
    Message, Message_2, Message_3, Message_4, Message_5, Message_6 : Message_Manager.Msg_Owner
-     := new Message_Record'(Make_Empty_Message((1, 1), (1, 1), 0, 0));
+     := new Message_Record'(Make_Empty_Message((1, 1), (1, 1), 0, 0, 0));
    Message_ID : constant Message_Manager.Message_ID_Type:= 1;
    Message_ID_2 : constant Message_Manager.Message_ID_Type:= 2;
    Message_Status : Message_Manager.Status_Type;
@@ -82,6 +82,7 @@ begin
       Receiver_Address => (0, 1),
       Request_ID       => 4,
       Message_ID       => Message_ID,
+      Payload_Size     => 0,
       Priority         => 2));
 
    Message_4 := new Message_Record'(Make_Empty_Message
@@ -89,6 +90,7 @@ begin
       Receiver_Address => (1, 2),
       Request_ID       => 8,
       Message_ID       => Message_ID_2,
+      Payload_Size     => 0,
       Priority         => 5));
 
    Message_5 := new Message_Record'(Make_Empty_Message
@@ -96,6 +98,7 @@ begin
       Receiver_Address => (1, 2),
       Request_ID       => 1,
       Message_ID       => 1,
+      Payload_Size     => 0,
       Priority         => 1));
 
    Message_6 := new Message_Record'(Make_Empty_Message
@@ -103,6 +106,7 @@ begin
       Receiver_Address => (1, 2),
       Request_ID       => 1,
       Message_ID       => Message_ID_2,
+      Payload_Size     => 0,
       Priority         => 4));
 
 

--- a/src/check/message_manager.ads
+++ b/src/check/message_manager.ads
@@ -14,5 +14,4 @@ pragma Elaborate_All(CubedOS.Generic_Message_Manager);
 package Message_Manager is
   new CubedOS.Generic_Message_Manager
     (Domain_Number =>  1,
-     Module_Count  => 16,
-     Maximum_Message_Size => 1024);
+     Module_Count  => 16);

--- a/src/check/network_configuration.adb
+++ b/src/check/network_configuration.adb
@@ -3,15 +3,15 @@
 -- SUBJECT : Package for retrieving addresses and ports for Domains in a distributed CubedOS application
 -- AUTHOR  : (C) Copyright 2022 by Vermont Technical College
 ----------------------------------------------------------------------------------
-package body Network_Configuration is 
+package body Network_Configuration is
 
 	function Get_Address
-		(Domain_ID   : Domain_ID_Type) return Inet_Addr_Type
+		(Domain_ID : Domain_ID_Type) return Inet_Addr_Type
 	is
 	begin
 		return Local_Host_Addr;
 	end Get_Address;
-	
+
 	function Get_Port
 		(Domain_ID   : Domain_ID_Type) return Port_Type
 	is

--- a/src/modules/cubedos-file_server-api.adb
+++ b/src/modules/cubedos-file_server-api.adb
@@ -23,23 +23,23 @@ package body CubedOS.File_Server.API is
       Name           : in String;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Open_Request),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Mode_Type'Pos(Mode)), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Mode_Type'Pos(Mode)), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Name'Length), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Name'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(Name, Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(Name, Message.Payload.all, Position, Last);
       return Message;
    end Open_Request_Encode;
 
@@ -51,19 +51,19 @@ package body CubedOS.File_Server.API is
       Handle           : in API.File_Handle_Type;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(API.Open_Reply),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       return Message;
    end Open_Reply_Encode;
 
@@ -75,21 +75,21 @@ package body CubedOS.File_Server.API is
       Amount         : in Read_Size_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Read_Request),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
       return Message;
    end Read_Request_Encode;
 
@@ -103,23 +103,23 @@ package body CubedOS.File_Server.API is
       Data             : in Octet_Array;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(API.Read_Reply),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Extended_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(Data(Data'First ..  Data'First + (Amount - 1)), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(Data(Data'First ..  Data'First + (Amount - 1)), Message.Payload.all, Position, Last);
       return Message;
    end Read_Reply_Encode;
 
@@ -132,23 +132,23 @@ package body CubedOS.File_Server.API is
       Data           : in Octet_Array;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Write_Request),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(Data(Data'First .. Data'First + (Amount - 1)), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(Data(Data'First .. Data'First + (Amount - 1)), Message.Payload.all, Position, Last);
       return Message;
    end Write_Request_Encode;
 
@@ -161,21 +161,21 @@ package body CubedOS.File_Server.API is
       Amount           : in Write_Result_Size_Type;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(API.Write_Reply),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
       return Message;
    end Write_Reply_Encode;
 
@@ -186,19 +186,19 @@ package body CubedOS.File_Server.API is
       Handle         : in Valid_File_Handle_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Close_Request),
+         Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       return Message;
    end Close_Request_Encode;
 
@@ -224,7 +224,7 @@ package body CubedOS.File_Server.API is
 
       -- TODO: Need to verify the conversions below. Returned Malformed if they won't work.
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Mode, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Mode, Last);
       Position := Last + 1;
       if Raw_Mode <= Mode_Type'Pos(Mode_Type'Last) then
          Mode := Mode_Type'Val(Raw_Mode);
@@ -232,14 +232,14 @@ package body CubedOS.File_Server.API is
          Decode_Status := Malformed;
          Mode := Mode_Type'First; -- appropriate?
       end if;
-      XDR.Decode(Message.Payload, Position, Raw_Name_Size, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Name_Size, Last);
       Position := Last + 1;
       if Raw_Name_Size <= XDR.XDR_Unsigned(Natural'Last) then
          Name_Size := Natural(Raw_Name_Size);
       else
          Name_Size := 0;
       end if;
-      XDR.Decode(Message.Payload, Position, Name(Name'First .. Name'First + (Name_Size - 1)), Last);
+      XDR.Decode(Message.Payload.all, Position, Name(Name'First .. Name'First + (Name_Size - 1)), Last);
    end Open_Request_Decode;
 
 
@@ -257,7 +257,7 @@ package body CubedOS.File_Server.API is
         (Off, "unused assignment to ""Last""", Reason => "No further decoding required");
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Handle, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Handle, Last);
       if Raw_Handle <= XDR.XDR_Unsigned(File_Handle_Type'Last)
       then
          Handle := File_Handle_Type(Raw_Handle);
@@ -287,7 +287,7 @@ package body CubedOS.File_Server.API is
 
       -- TODO: Need to verify the conversions below. Returned Malformed if they won't work.
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Handle, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Handle, Last);
       Position := Last + 1;
       if Raw_Handle in XDR.XDR_Unsigned(Valid_File_Handle_Type'First) ..
                        XDR.XDR_Unsigned(Valid_File_Handle_Type'Last)
@@ -297,7 +297,7 @@ package body CubedOS.File_Server.API is
          Decode_Status := Malformed;
          Handle := Valid_File_Handle_Type'First;
       end if;
-      XDR.Decode(Message.Payload, Position, Raw_Amount, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Amount, Last);
       if Raw_Amount in XDR.XDR_Unsigned(Read_Size_Type'First) ..
                        XDR.XDR_Unsigned(Read_Size_Type'Last)
       then
@@ -324,9 +324,9 @@ package body CubedOS.File_Server.API is
       pragma Warnings
         (Off, "unused assignment to ""Last""", Reason => "No further decoding required");
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Handle, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Handle, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Amount, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Amount, Last);
       Position := Last + 1;
       Data := (others => 0);
       if Raw_Handle in XDR.XDR_Unsigned(Valid_File_Handle_Type'First) ..
@@ -335,7 +335,7 @@ package body CubedOS.File_Server.API is
       then
          Handle := Valid_File_Handle_Type(Raw_Handle);
          Amount := Read_Result_Size_Type(Raw_Amount);
-         XDR.Decode(Message.Payload, Position, Data(Data'First .. Data'First + (Amount - 1)), Last);
+         XDR.Decode(Message.Payload.all, Position, Data(Data'First .. Data'First + (Amount - 1)), Last);
          Decode_Status := Success;
       else
          Handle := Valid_File_Handle_Type'First;
@@ -364,7 +364,7 @@ package body CubedOS.File_Server.API is
 
       -- TODO: Need to verify the conversions below. Returned Malformed if they won't work.
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Handle, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Handle, Last);
       if Raw_Handle in XDR.XDR_Unsigned(Valid_File_Handle_Type'First) ..
                        XDR.XDR_Unsigned(Valid_File_Handle_Type'Last)
       then
@@ -374,7 +374,7 @@ package body CubedOS.File_Server.API is
          Handle := Valid_File_Handle_Type'First; -- Is that what this should be?
       end if;
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Amount, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Amount, Last);
       if Raw_Amount in XDR.XDR_Unsigned(Write_Result_Size_Type'First + 1) ..
                        XDR.XDR_Unsigned(Write_Result_Size_Type'Last)
       then
@@ -384,7 +384,7 @@ package body CubedOS.File_Server.API is
       end if;
       Position := Last + 1;
       Data := (others => 0);
-      XDR.Decode(Message.Payload, Position, Data(Data'First .. Data'First + (Amount - 1)), Last);
+      XDR.Decode(Message.Payload.all, Position, Data(Data'First .. Data'First + (Amount - 1)), Last);
    end Write_Request_Decode;
 
 
@@ -402,9 +402,9 @@ package body CubedOS.File_Server.API is
       pragma Warnings
         (Off, "unused assignment to ""Last""", Reason => "No further decoding required");
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Handle, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Handle, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Amount, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Amount, Last);
       if Raw_Handle in XDR.XDR_Unsigned(Valid_File_Handle_Type'First) ..
           XDR.XDR_Unsigned(Valid_File_Handle_Type'Last) and
          Raw_Amount <= XDR.XDR_Unsigned(Write_Result_Size_Type'Last)
@@ -436,7 +436,7 @@ package body CubedOS.File_Server.API is
 
       -- TODO: Need to verify the conversions below. Returned Malformed if they won't work.
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Handle, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Handle, Last);
       if Raw_Handle in XDR.XDR_Unsigned(Valid_File_Handle_Type'First) ..
                        XDR.XDR_Unsigned(Valid_File_Handle_Type'Last)
       then

--- a/src/modules/cubedos-interpreter-api.adb
+++ b/src/modules/cubedos-interpreter-api.adb
@@ -46,9 +46,9 @@ package body CubedOS.Interpreter.API is
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
       -- The skeletal message knows its sender (this module).
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
-          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Set_Reply), Priority);
+          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Set_Reply), Max_Message_Size, Priority);
 
       Position : Data_Index_Type;
       Last     : Data_Index_Type;
@@ -58,11 +58,10 @@ package body CubedOS.Interpreter.API is
 
       -- Encode one parameter (decoding logic must be consistent).
       -- Set Position to get ready for the next parameter.
-      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       Position := Last + 1;
 
       -- Set the message size.
-      Message.Size := Last + 1;
       return Message;
    end Set_Reply_Encode;
 
@@ -88,9 +87,9 @@ package body CubedOS.Interpreter.API is
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
       -- The skeletal message knows its sender (this module).
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
-          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Add_Reply), Priority);
+          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Add_Reply), Max_Message_Size, Priority);
 
       Position : Data_Index_Type;
       Last     : Data_Index_Type;
@@ -100,11 +99,10 @@ package body CubedOS.Interpreter.API is
 
       -- Encode one parameter (decoding logic must be consistent).
       -- Set Position to get ready for the next parameter.
-      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       Position := Last + 1;
 
       -- Set the message size.
-      Message.Size := Last + 1;
       return Message;
    end Add_Reply_Encode;
 
@@ -134,7 +132,7 @@ package body CubedOS.Interpreter.API is
 
       -- Decode one parameter (encoding logic must be consistent).
       -- Set position to get ready for next parameter.
-      XDR.Decode(Message.Payload, Position, Raw_Value, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Value, Last);
       Position := Last + 1;
 
       -- Convert raw XDR primitive type into appropriate result. Note runtime check needed!
@@ -165,7 +163,7 @@ package body CubedOS.Interpreter.API is
 
       -- Decode one parameter (encoding logic must be consistent).
       -- Set position to get ready for next parameter.
-      XDR.Decode(Message.Payload, Position, Raw_Value, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Value, Last);
       Position := Last + 1;
 
       -- Convert raw XDR primitive type into appropriate result. Note runtime check needed!

--- a/src/modules/cubedos-log_server-api.adb
+++ b/src/modules/cubedos-log_server-api.adb
@@ -33,23 +33,23 @@ package body CubedOS.Log_Server.API is
       Text           : in String;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Sender_Address,
            Receiver_Address => Name_Resolver.Log_Server,
            Request_ID       => Request_ID,
            Message_ID       => Message_Type'Pos(Log_Text),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority         => Priority);
       Position : Data_Index_Type;
       Last : Data_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Log_Level_Type'Pos(Log_Level)), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Log_Level_Type'Pos(Log_Level)), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Text'Length), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Text'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(Text, Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(Text, Message.Payload.all, Position, Last);
       return Message;
    end Log_Text_Encode;
 
@@ -69,7 +69,7 @@ package body CubedOS.Log_Server.API is
    begin
       Text := (others => ' ');
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Log_Level, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Log_Level, Last);
       Position := Last + 1;
       if Raw_Log_Level > Log_Level_Type'Pos(Log_Level_Type'Last) then
          Log_Level     := Critical;
@@ -77,7 +77,7 @@ package body CubedOS.Log_Server.API is
          Decode_Status := Malformed;
       else
          Log_Level := Log_Level_Type'Val(Raw_Log_Level);
-         XDR.Decode(Message.Payload, Position, Raw_Size, Last);
+         XDR.Decode(Message.Payload.all, Position, Raw_Size, Last);
          Position := Last + 1;
          if Raw_Size > Maximum_Log_Message_Size then
             Log_Level     := Critical;
@@ -89,7 +89,7 @@ package body CubedOS.Log_Server.API is
             pragma Warnings
               (Off, """Last"" is set by ""Decode"" but not used after the call",
                     Reason  => "The last value of Last is not needed");
-            XDR.Decode(Message.Payload, Position, Raw_Text(1 .. Size), Last);
+            XDR.Decode(Message.Payload.all, Position, Raw_Text(1 .. Size), Last);
             Text(Text'First .. (Text'First - 1) + Size) := Raw_Text(1 .. Size);
             Decode_Status := Success;
          end if;

--- a/src/modules/cubedos-publish_subscribe_server-api.adb
+++ b/src/modules/cubedos-publish_subscribe_server-api.adb
@@ -23,19 +23,19 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Channel    : in Channel_ID_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Subscribe_Request),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       return Message;
    end Subscribe_Request_Encode;
 
@@ -47,21 +47,21 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status     : in Status_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Subscribe_Reply),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       return Message;
    end Subscribe_Reply_Encode;
 
@@ -72,19 +72,19 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Channel        : in Channel_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Unsubscribe_Request),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       return Message;
    end Unsubscribe_Request_Encode;
 
@@ -96,21 +96,21 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status     : in Status_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Unsubscribe_Reply),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       return Message;
    end Unsubscribe_Reply_Encode;
 
@@ -122,23 +122,23 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Message_Data : in CubedOS.Lib.Octet_Array;
       Priority     : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Publish_Request),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Message_Data'Length), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Message_Data'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(Message_Data, Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(Message_Data, Message.Payload.all, Position, Last);
       return Message;
    end Publish_Request_Encode;
 
@@ -150,21 +150,21 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status     : in Status_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Publish_Reply),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       return Message;
    end Publish_Reply_Encode;
 
@@ -176,23 +176,23 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Message_Data : in CubedOS.Lib.Octet_Array;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : Message_Record :=
+      Message : constant Message_Record :=
         Make_Empty_Message
           (Sender_Address => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
            Message_ID => Message_Type'Pos(Publish_Result),
+           Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
       Last : XDR_Index_Type;
    begin
       Position := 0;
-      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(XDR.XDR_Unsigned(Message_Data'Length), Message.Payload, Position, Last);
+      XDR.Encode(XDR.XDR_Unsigned(Message_Data'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
-      XDR.Encode(Message_Data, Message.Payload, Position, Last);
-      Message.Size := Last + 1;
+      XDR.Encode(Message_Data, Message.Payload.all, Position, Last);
       return Message;
    end Publish_Result_Encode;
 
@@ -209,7 +209,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Channel := Channel_ID_Type'First;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
          Raw_Channel > XDR_Unsigned(Channel_ID_Type'Last)
@@ -237,9 +237,9 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status := Failure;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Status, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Status, Last);
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
          Raw_Channel > XDR_Unsigned(Channel_ID_Type'Last)
@@ -269,7 +269,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Channel := Channel_ID_Type'First;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
          Raw_Channel > XDR_Unsigned(Channel_ID_Type'Last)
@@ -297,9 +297,9 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status := Failure;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Status, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Status, Last);
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
          Raw_Channel > XDR_Unsigned(Channel_ID_Type'Last)
@@ -334,9 +334,9 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Size := 0;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Size, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Size, Last);
       Position := Last + 1;
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
@@ -354,7 +354,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
                Size := 0;
             else
                XDR.Decode
-                 (Message.Payload,
+                 (Message.Payload.all,
                   Position,
                   Message_Data(Message_Data'First .. Message_Data'First + Size - 1),
                   Last);
@@ -380,9 +380,9 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status := Failure;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Status, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Status, Last);
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
          Raw_Channel > XDR_Unsigned(Channel_ID_Type'Last)
@@ -417,9 +417,9 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Size := 0;
 
       Position := 0;
-      XDR.Decode(Message.Payload, Position, Raw_Channel, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Channel, Last);
       Position := Last + 1;
-      XDR.Decode(Message.Payload, Position, Raw_Size, Last);
+      XDR.Decode(Message.Payload.all, Position, Raw_Size, Last);
       Position := Last + 1;
 
       if Raw_Channel < XDR_Unsigned(Channel_ID_Type'First) or
@@ -437,7 +437,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
                Size := 0;
             else
                XDR.Decode
-                 (Message.Payload,
+                 (Message.Payload.all,
                   Position,
                   Message_Data(Message_Data'First .. Message_Data'First + Size - 1),
                   Last);

--- a/src/modules/cubedos-publish_subscribe_server-messages.adb
+++ b/src/modules/cubedos-publish_subscribe_server-messages.adb
@@ -76,7 +76,7 @@ is
      with Pre => Is_Publish_Request(Message)
    is
       Channel : Channel_ID_Type;
-      Message_Data : CubedOS.Lib.Octet_Array(1 .. Data_Size_Type'Last - 8);
+      Message_Data : CubedOS.Lib.Octet_Array(1 .. Message.Payload'Length - 8);
       Size    : CubedOS.Lib.Octet_Array_Count;
       Status  : Message_Status_Type;
    begin


### PR DESCRIPTION
Message_Record now holds a pointer to a Data_Array.
Data_Array has variable length which is decided during
calls to Make_Empty_Message. Removed the Size component
of Message_Record because now users can just check the
Payload'Length attribute.

The generic message manager package no longer takes
a Maximum message length parameter. I added a constant
Max_Message_Length to the message manager so I didn't have
to replace all the API encoder calls in this commit. This
constant should have all its references removed and be
deleted.

The tests may be passing but I'm 90% certain that
the message system is not functional after this commit.