### PR TITLE
Add message type checking

### DIFF
--- a/src/check/check_message_passing.adb
+++ b/src/check/check_message_passing.adb
@@ -1,0 +1,53 @@
+---------------------------------------------------------------------------
+-- FILE    : check_message_passing.adb
+-- SUBJECT : Package containing tests of the message system.
+-- AUTHOR  : (C) Copyright 2023 by Vermont Technical College
+--
+---------------------------------------------------------------------------
+with Message_Manager; use Message_Manager;
+
+package body Check_Message_Passing is
+
+   -- Modules declare what message types they are allowed to receive.
+   -- Test that sending a message to a module that doesn't support it
+   -- throws an exception before the message reaches the module,
+   -- but an acceptable message reaches its destination.
+   procedure Test_Msg_Type_Checking is
+      Unnacceptable_Type : constant Universal_Message_Type := (1, 0);
+      Acceptable_Type : constant Universal_Message_Type := (1, 1);
+
+      Sender_Addr : constant Message_Address := (0, 1);
+      Receiver_Addr : constant Message_Address := (0, 2);
+
+      Unacceptable_Msg : constant Message_Record := Make_Empty_Message
+        (Sender_Addr, Receiver_Addr, 0, Unnacceptable_Type, 0);
+      Acceptable_Msg : constant Message_Record := Make_Empty_Message
+        (Sender_Addr, Receiver_Addr, 0, Acceptable_Type, 0);
+
+      Sender : Module_Mailbox;
+      Receiver : Module_Mailbox;
+   begin
+      -- Register mailboxes
+      Register_Module(Sender_Addr.Module_ID, 1, Sender, Unchecked_Type);
+      Register_Module(Receiver_Addr.Module_ID, 1, Receiver, (0 => Acceptable_Type));
+
+      -- Check that acceptable message reaches receiver
+      Send_Message(Sender, Acceptable_Msg);
+      pragma Assert(Queue_Size(Receiver) = 1, "Acceptable message wasn't received.");
+
+      -- Check that unacceptable message throws an exception
+      declare
+      begin
+         Send_Message(Sender, Unacceptable_Msg);
+         pragma Assert(False, "Unacceptable message was sent without objection.");
+      exception
+         when others => pragma Assert(True, "Unnacceptable message raised error on send.");
+      end;
+   end Test_Msg_Type_Checking;
+
+   procedure Run_Tests is
+   begin
+      Test_Msg_Type_Checking;
+   end Run_Tests;
+
+end Check_Message_Passing;

--- a/src/check/check_message_passing.ads
+++ b/src/check/check_message_passing.ads
@@ -1,0 +1,14 @@
+---------------------------------------------------------------------------
+-- FILE    : check_message_passing.ads
+-- SUBJECT : Package containing tests for the message system.
+-- AUTHOR  : (C) Copyright 2023 by Vermont Technical College
+--
+-- Tests intra-domain message passing.
+--
+---------------------------------------------------------------------------
+
+package Check_Message_Passing is
+
+   procedure Run_Tests;
+
+end Check_Message_Passing;

--- a/src/check/check_modules.adb
+++ b/src/check/check_modules.adb
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------------
+-- FILE    : check_modules.adb
+-- SUBJECT : Package containing tests for cubedos modules and message system.
+-- AUTHOR  : (C) Copyright 2023 by Vermont Technical College
+--
+---------------------------------------------------------------------------
+
+with Check_Message_Passing;
+
+-- Runs unit tests on the modules + message system.
+-- Conforms to the ravenscar profile
+-- When you run this, silence means everything is ok.
+procedure Check_Modules is
+begin
+   Check_Message_Passing.Run_Tests;
+end Check_Modules;

--- a/src/check/main.adb
+++ b/src/check/main.adb
@@ -20,14 +20,14 @@ with CubedOS.Interpreter.Messages;
 with CubedOS.Log_Server.Messages;
 with CubedOS.Publish_Subscribe_Server.Messages;
 with CubedOS.Time_Server.Messages;
-with CubedOS.Transport_UDP.Messages;
+--with CubedOS.Transport_UDP.Messages;
 
 pragma Unreferenced(CubedOS.File_Server.Messages);
 pragma Unreferenced(CubedOS.Interpreter.Messages);
 pragma Unreferenced(CubedOS.Log_Server.Messages);
 pragma Unreferenced(CubedOS.Publish_Subscribe_Server.Messages);
 pragma Unreferenced(CubedOS.Time_Server.Messages);
-pragma Unreferenced(CubedOS.Transport_UDP.Messages);
+--pragma Unreferenced(CubedOS.Transport_UDP.Messages);
 
 procedure Main is
 

--- a/src/check/main_file.adb
+++ b/src/check/main_file.adb
@@ -34,7 +34,7 @@ procedure Main_File is
    Data   : Lib.Octet_Array(0 .. Maximum_Read_Size - 1);
    Status : Message_Manager.Message_Status_Type;
 begin
-   Register_Module(My_Module_ID, 8, My_Mailbox);
+   Register_Module(My_Module_ID, 8, My_Mailbox, Unchecked_Type);
 
    -- TEST : Open two files. Read from one file, and write to another file.
 
@@ -51,9 +51,7 @@ begin
    loop
       Message_Manager.Read_Next(My_Mailbox, Incoming_Message);
       Put_Line("+++ Fetch returned!");
-      Put_Line("+++    Sender    : " & Module_ID_Type'Image(Incoming_Message.Sender_Address.Module_ID));
-      Put_Line("+++    Receiver  : " & Module_ID_Type'Image(Incoming_Message.Receiver_Address.Module_ID));
-      Put_Line("+++    Message_ID: " & Message_ID_Type'Image(Incoming_Message.Message_ID));
+      Put_Line(Message_Manager.Stringify_Message(Incoming_Message.all));
       New_Line;
 
       -- Process open reply messages.

--- a/src/check/main_message_manager.adb
+++ b/src/check/main_message_manager.adb
@@ -7,9 +7,9 @@ use Message_Manager;
 procedure Main_Message_Manager is
 
    Message, Message_2, Message_3, Message_4, Message_5, Message_6 : Message_Manager.Msg_Owner
-     := new Message_Record'(Make_Empty_Message((1, 1), (1, 1), 0, 0, 0));
-   Message_ID : constant Message_Manager.Message_ID_Type:= 1;
-   Message_ID_2 : constant Message_Manager.Message_ID_Type:= 2;
+     := new Message_Record'(Make_Empty_Message((1, 1), (1, 1), 0, (1, 1), 0));
+   Message_Type : constant Message_Manager.Universal_Message_Type := (1, 1);
+   Message_Type_2 : constant Message_Manager.Universal_Message_Type := (1, 2);
    Message_Status : Message_Manager.Status_Type;
    X : Integer := 1;
    Mailbox_1, Mailbox_2 : Message_Manager.Module_Mailbox;
@@ -22,10 +22,7 @@ procedure Main_Message_Manager is
       while Y < 9 loop
          Message_Manager.Read_Next(Mailbox_1, Message);
          Put_Line("Message " & Integer'Image(Y) & " fetched ");
-         Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message.Sender_Address.Module_ID));
-         Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message.Receiver_Address.Module_ID));
-         Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message.Message_ID));
-         Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message.Request_ID));
+         Put_Line(Message_Manager.Stringify_Message(Message.all));
          New_Line;
 
          Y := Y + 1;
@@ -42,10 +39,7 @@ procedure Main_Message_Manager is
       while Y < 9 loop
          Message_Manager.Read_Next(Mailbox_2, Message_5);
          Put_Line("Message " & Integer'Image(Y) & " fetched ");
-         Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_5.Sender_Address.Module_ID));
-         Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver_Address.Module_ID));
-         Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message_5.Message_ID));
-         Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message_5.Request_ID));
+         Put_Line(Message_Manager.Stringify_Message(Message.all));
          New_Line;
 
          Y := Y + 1;
@@ -56,8 +50,8 @@ procedure Main_Message_Manager is
 
 begin
    -- Register receiving mailboxes
-   Message_Manager.Register_Module(1, 8, Mailbox_1);
-   Message_Manager.Register_Module(2, 8, Mailbox_2);
+   Message_Manager.Register_Module(1, 8, Mailbox_1, Unchecked_Type);
+   Message_Manager.Register_Module(2, 8, Mailbox_2, Unchecked_Type);
 
    -- Test Get_Next_Request_ID
    Put_Line("Testing Get_Next_Request_ID");
@@ -81,7 +75,7 @@ begin
      (Sender_Address   => (0, 2),
       Receiver_Address => (0, 1),
       Request_ID       => 4,
-      Message_ID       => Message_ID,
+      Message_Type     => Message_Type,
       Payload_Size     => 0,
       Priority         => 2));
 
@@ -89,7 +83,7 @@ begin
      (Sender_Address   => (1, 1),
       Receiver_Address => (1, 2),
       Request_ID       => 8,
-      Message_ID       => Message_ID_2,
+      Message_Type       => Message_Type_2,
       Payload_Size     => 0,
       Priority         => 5));
 
@@ -97,7 +91,7 @@ begin
      (Sender_Address   => (2, 2),
       Receiver_Address => (1, 2),
       Request_ID       => 1,
-      Message_ID       => 1,
+      Message_Type       => Message_Type,
       Payload_Size     => 0,
       Priority         => 1));
 
@@ -105,7 +99,7 @@ begin
      (Sender_Address   => (1, 2),
       Receiver_Address => (1, 2),
       Request_ID       => 1,
-      Message_ID       => Message_ID_2,
+      Message_Type       => Message_Type_2,
       Payload_Size     => 0,
       Priority         => 4));
 
@@ -119,10 +113,7 @@ begin
          Route_Message(Message => Message_3.all, Status => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_3.Sender_Address.Module_ID));
-         Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_3.Receiver_Address.Module_ID));
-         Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message_3.Message_ID));
-         Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message_3.Request_ID));
+         Put_Line(Message_Manager.Stringify_Message(Message.all));
          New_Line;
          X := X + 1;
 
@@ -130,10 +121,7 @@ begin
          Route_Message(Message => Message_4.all, Status  => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_4.Sender_Address.Module_ID));
-         Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_4.Receiver_Address.Module_ID));
-         Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message_4.Message_ID));
-         Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message_4.Request_ID));
+         Put_Line(Message_Manager.Stringify_Message(Message.all));
          New_Line;
          X := X + 1;
 
@@ -141,10 +129,7 @@ begin
          Route_Message(Message => Message_5.all, Status  => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_5.Sender_Address.Module_ID));
-         Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_5.Receiver_Address.Module_ID));
-         Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message_5.Message_ID));
-         Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message_5.Request_ID));
+         Put_Line(Message_Manager.Stringify_Message(Message.all));
          New_Line;
          X := X + 1;
 
@@ -154,10 +139,7 @@ begin
          Route_Message(Message => Message_2.all);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_2.Sender_Address.Module_ID));
-         Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_2.Receiver_Address.Module_ID));
-         Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message_2.Message_ID));
-         Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message_2.Request_ID));
+         Put_Line(Message_Manager.Stringify_Message(Message.all));
          New_Line;
          X := X + 1;
 
@@ -167,10 +149,7 @@ begin
             Route_Message(Message => Message.all, Status => Message_Status);
             Put_Line("Message" & Integer'Image(X) & " routed");
             Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-            Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message.Sender_Address.Module_ID));
-            Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message.Receiver_Address.Module_ID));
-            Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message.Message_ID));
-            Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message.Request_ID));
+            Put_Line(Message_Manager.Stringify_Message(Message.all));
             New_Line;
             X := X + 1;
          end if;
@@ -179,10 +158,7 @@ begin
             Route_Message(Message => Message_6.all, Status => Message_Status);
             Put_Line("Message" & Integer'Image(X) & " routed");
             Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-            Put_Line("+++ Sender ID   : " & Module_ID_Type'Image (Message_6.Sender_Address.Module_ID));
-            Put_Line("+++ Reciever ID : " & Module_ID_Type'Image (Message_6.Receiver_Address.Module_ID));
-            Put_Line("+++ Message ID  : " & Message_ID_Type'Image(Message_6.Message_ID));
-            Put_Line("+++ Request ID  : " & Request_ID_Type'Image(Message_6.Request_ID));
+            Put_Line(Message_Manager.Stringify_Message(Message.all));
             New_Line;
             X := X + 1;
          end if;

--- a/src/check/main_time.adb
+++ b/src/check/main_time.adb
@@ -43,7 +43,7 @@ procedure Main_Time is
    use Duration_IO;
 begin
    Start_Time := Ada.Real_Time.Clock;
-   Message_Manager.Register_Module(My_Module_ID, 8, My_Mailbox);
+   Message_Manager.Register_Module(My_Module_ID, 8, My_Mailbox, Message_Manager.Unchecked_Type);
 
    -- Do some setup...
    Message_Manager.Send_Message

--- a/src/cubedos.gpr
+++ b/src/cubedos.gpr
@@ -1,10 +1,9 @@
 with "aunit.gpr";
-with "library/cubedlib.gpr";        
-        
+with "library/cubedlib.gpr";
+
 project CubedOS is
 
-   for Main use ("main.adb", "main_message_manager.adb", "main_file.adb", "main_time.adb",
-"cubedos_check.adb");
+   for Main use ("main.adb", "main_message_manager.adb", "main_file.adb", "main_time.adb", "cubedos_check.adb", "check_modules.adb");
    for Object_Dir use "check/build";
    for Source_Dirs use ("check", "modules");
    for Languages use ("ada");
@@ -20,7 +19,7 @@ project CubedOS is
    package Builder is
    end Builder;
 
-   package Documentation is     
+   package Documentation is
       for Ignored_Subprojects use ("aunit");
    end Documentation;
 

--- a/src/modules/cubedos-file_server-api.adb
+++ b/src/modules/cubedos-file_server-api.adb
@@ -27,7 +27,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Open_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Open_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -55,7 +55,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(API.Open_Reply),
+         Message_Type => (This_Module, Message_Type'Pos(API.Open_Reply)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -79,7 +79,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Read_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Read_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -107,7 +107,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(API.Read_Reply),
+         Message_Type => (This_Module, Message_Type'Pos(API.Read_Reply)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -136,7 +136,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Write_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Write_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -165,7 +165,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(API.Write_Reply),
+         Message_Type => (This_Module, Message_Type'Pos(API.Write_Reply)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -190,7 +190,7 @@ package body CubedOS.File_Server.API is
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Close_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Close_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 

--- a/src/modules/cubedos-file_server-api.ads
+++ b/src/modules/cubedos-file_server-api.ads
@@ -17,6 +17,8 @@ use Message_Manager;
 
 package CubedOS.File_Server.API is
 
+   This_Module : constant Module_ID_Type := Name_Resolver.File_Server.Module_ID;
+
    type Message_Type is
      (Open_Request,
       Open_Reply,
@@ -25,6 +27,15 @@ package CubedOS.File_Server.API is
       Write_Request,
       Write_Reply,
       Close_Request);
+
+   -- Describe the message types
+   Open_Request_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Open_Request));
+   Open_Reply_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Open_Reply));
+   Read_Request_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Read_Request));
+   Read_Reply_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Read_Reply));
+   Write_Request_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Write_Request));
+   Write_Reply_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Write_Reply));
+   Close_Request_Msg : constant Universal_Message_Type := (This_Module, Message_Type'Pos(Close_Request));
 
    type Mode_Type is (Read, Write);
    type File_Handle_Type is range 0 .. 64;
@@ -109,25 +120,25 @@ package CubedOS.File_Server.API is
 
 
    function Is_Open_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Open_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Open_Request)));
 
    function Is_Open_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Open_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Open_Reply)));
 
    function Is_Read_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Read_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Read_Request)));
 
    function Is_Read_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Read_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Read_Reply)));
 
    function Is_Write_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Write_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Write_Request)));
 
    function Is_Write_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Write_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Write_Reply)));
 
    function Is_Close_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.File_Server and Message.Message_ID = Message_Type'Pos(Close_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Close_Request)));
 
 
 

--- a/src/modules/cubedos-file_server-messages.adb
+++ b/src/modules/cubedos-file_server-messages.adb
@@ -219,5 +219,11 @@ package body CubedOS.File_Server.Messages is
    end Message_Loop;
 
 begin
-      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
+   Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox,
+                                   (
+                                    CubedOS.File_Server.API.Open_Request_Msg,
+                                    CubedOS.File_Server.API.Read_Request_Msg,
+                                    CubedOS.File_Server.API.Write_Request_Msg,
+                                    CubedOS.File_Server.API.Close_Request_Msg
+                                   ));
 end CubedOS.File_Server.Messages;

--- a/src/modules/cubedos-generic_message_manager.adb
+++ b/src/modules/cubedos-generic_message_manager.adb
@@ -10,8 +10,8 @@ with Ada.Unchecked_Deallocation;
 -- with Name_Resolver;
 
 package body CubedOS.Generic_Message_Manager with
-   Refined_State => (Mailboxes => Message_Storage,
-    Mailbox_Init_Tracker => Inited, Request_ID_Generator => Request_ID_Gen)
+   Refined_State => (Mailboxes => (Message_Storage),
+    Mailbox_Init_Tracker => Inited, Receiver_Types => Mailbox_Types, Request_ID_Generator => Request_ID_Gen)
 is
 
    procedure Free is new Ada.Unchecked_Deallocation
@@ -25,6 +25,7 @@ is
    end Request_ID_Gen;
 
    type Msg_Ptr_Array_Ptr is access Message_Ptr_Array;
+   type Msg_Type_Array_Ptr is access Message_Type_Array;
 
    -- A protected type for holding messages.
    protected type Sync_Mailbox is
@@ -51,7 +52,7 @@ is
       procedure Set_Msg_Array (Arr : in out Msg_Ptr_Array_Ptr);
 
    private
-      Messages        : Msg_Ptr_Array_Ptr;
+      Messages        : Msg_Ptr_Array_Ptr  := null;
       Count           : Message_Count_Type := 0;
       Next_In         : Message_Index_Type := 1;
       Next_Out        : Message_Index_Type := 1;
@@ -61,7 +62,10 @@ is
 
    -- One mailbox for each module.
    Message_Storage : array (Module_ID_Type) of Sync_Mailbox;
+   Mailbox_Types   : array (Module_ID_Type) of Msg_Type_Array_Ptr;
    Inited          : array (Module_ID_Type) of Boolean := (others => False);
+
+   Unchecked_Type_Access : constant Msg_Type_Array_Ptr := new Message_Type_Array'(Unchecked_Type);
 
    function Module_Ready (Module_ID : Module_ID_Type) return Boolean is
      (Inited (Module_ID));
@@ -146,7 +150,7 @@ is
 
    function Make_Empty_Message
      (Sender_Address : Message_Address; Receiver_Address : Message_Address;
-      Request_ID     : Request_ID_Type; Message_ID : Message_ID_Type;
+      Request_ID     : Request_ID_Type; Message_Type : Universal_Message_Type;
       Payload_Size : Natural;
       Priority       : System.Priority := System.Default_Priority)
       return Message_Record
@@ -157,7 +161,7 @@ is
               Sender_Address => Sender_Address,
               Receiver_Address => Receiver_Address,
               Request_ID => Request_ID,
-              Message_ID => Message_ID,
+              Message_Type => Message_Type,
               Priority => Priority,
               Payload => new Definite_Data_Array'(others => 0)
              );
@@ -175,7 +179,7 @@ is
       Request_ID_String : constant String :=
         Request_ID_Type'Image (Message.Request_ID);
       Message_ID_String : constant String :=
-        Message_ID_Type'Image (Message.Message_ID);
+        Module_ID_Type'Image(Message.Message_Type.Module_ID) & Message_ID_Type'Image (Message.Message_Type.Message_ID);
       Message_Image : constant String :=
         Sender_Domain_String & "!" & Sender_Module_String & "!" &
         Receiver_Domain_String & "!" & Receiver_Module_String & "!" &
@@ -189,6 +193,9 @@ is
       Request_ID_Gen.Generate_Next_ID (Request_ID);
    end Get_Next_Request_ID;
 
+   function Receives(Receiver : Message_Address; Msg_Type : Universal_Message_Type) return Boolean
+     is (if Mailbox_Types(Receiver.Module_ID) /= Unchecked_Type_Access then (for some T of Mailbox_Types(Receiver.Module_ID).all => T = Msg_Type));
+
    procedure Route_Message
      (Message : in out Msg_Owner; Status : out Status_Type)
    is
@@ -196,6 +203,7 @@ is
       -- For now, let's ignore the domain and just use the receiver Module_ID only.
       Message_Storage (Message.Receiver_Address.Module_ID).Send
         (Message, Status);
+      Message := null;
    end Route_Message;
 
    procedure Route_Message (Message : in out Msg_Owner) is
@@ -207,6 +215,7 @@ is
       else
          Message_Storage (Message.Receiver_Address.Module_ID).Unchecked_Send
            (Message);
+         Message := null;
       end if;
    end Route_Message;
 
@@ -232,7 +241,7 @@ is
                                 Sender_Address => Msg.Sender_Address,
                                 Receiver_Address => Msg.Receiver_Address,
                                 Request_ID => Msg.Request_ID,
-                                Message_ID => Msg.Message_ID,
+                                Message_Type => Msg.Message_Type,
                                 Priority => Msg.Priority,
                                 Payload => new Definite_Data_Array'(Msg.Payload.all)
                                );
@@ -245,6 +254,10 @@ is
    begin
       Message_Storage (Module).Receive (Message);
    end Fetch_Message;
+
+   -------------
+   -- Mailbox
+   -------------
 
    procedure Send_Message (Box : Module_Mailbox; Msg : Message_Record) is
       Ptr : Msg_Owner := Copy(Msg);
@@ -265,14 +278,23 @@ is
       Fetch_Message (Box.Address.Module_ID, Msg);
    end Read_Next;
 
+   function Queue_Size(Box : Module_Mailbox) return Natural is
+      (Message_Storage (Box.Address.Module_ID).Message_Count);
+
    procedure Register_Module
      (Module_ID : in     Module_ID_Type; Msg_Queue_Size : in Positive;
-      Mailbox   :    out Module_Mailbox)
+      Mailbox   :    out Module_Mailbox; Receives : in Message_Type_Array)
    is
       Arr : Msg_Ptr_Array_Ptr := new Message_Ptr_Array (1 .. Msg_Queue_Size);
    begin
       -- Create a new mailbox for the ID
       Message_Storage (Module_ID).Set_Msg_Array (Arr);
+      if Receives = Unchecked_Type then
+         Mailbox_Types (Module_ID) := Unchecked_Type_Access;
+      else
+         Mailbox_Types (Module_ID) := new Message_Type_Array'(Receives);
+      end if;
+
       Mailbox            := (Address => (Domain_ID, Module_ID));
       Inited (Module_ID) := True;
    end Register_Module;

--- a/src/modules/cubedos-generic_message_manager.adb
+++ b/src/modules/cubedos-generic_message_manager.adb
@@ -151,16 +151,16 @@ is
       Priority       : System.Priority := System.Default_Priority)
       return Message_Record
    is
-      Message : Message_Record;
       subtype Definite_Data_Array is Data_Array(0 .. Payload_Size - 1);
    begin
-      Message.Sender_Address   := Sender_Address;
-      Message.Receiver_Address := Receiver_Address;
-      Message.Request_ID       := Request_ID;
-      Message.Message_ID       := Message_ID;
-      Message.Priority         := Priority;
-      Message.Payload          := new Definite_Data_Array'(others => 0);
-      return Message;
+      return (
+              Sender_Address => Sender_Address,
+              Receiver_Address => Receiver_Address,
+              Request_ID => Request_ID,
+              Message_ID => Message_ID,
+              Priority => Priority,
+              Payload => new Definite_Data_Array'(others => 0)
+             );
    end Make_Empty_Message;
 
    function Stringify_Message (Message : in Message_Record) return String is

--- a/src/modules/cubedos-generic_message_manager.ads
+++ b/src/modules/cubedos-generic_message_manager.ads
@@ -74,12 +74,12 @@ is
    -- useful.
    type Message_Record is
       record
-         Sender_Address : Message_Address := (0, 1);
-         Receiver_Address : Message_Address := (0 , 1);
-         Request_ID : Request_ID_Type := 0;
-         Message_ID : Message_ID_Type := 0;
-         Priority   : System.Priority := System.Default_Priority;
-         Payload    : Data_Array_Owner := null;
+         Sender_Address : Message_Address;
+         Receiver_Address : Message_Address;
+         Request_ID : Request_ID_Type;
+         Message_ID : Message_ID_Type;
+         Priority   : System.Priority;
+         Payload    : not null Data_Array_Owner;
       end record;
 
    type Msg_Owner is access Message_Record;
@@ -210,6 +210,8 @@ private
          Address : Message_Address;
       end record;
 
+   -- Create a copy of the given message on the heap,
+   -- also making a copy of the payload content.
    function Copy(Msg : Message_Record) return Msg_Owner;
 
 end CubedOS.Generic_Message_Manager;

--- a/src/modules/cubedos-generic_message_manager.ads
+++ b/src/modules/cubedos-generic_message_manager.ads
@@ -18,7 +18,7 @@ generic
    Module_Count  : Positive;  -- Number of modules in the system.
 package CubedOS.Generic_Message_Manager
   with
-    Abstract_State => ((Mailboxes with External), Mailbox_Init_Tracker, (Request_ID_Generator with External)),
+    Abstract_State => ((Mailboxes with External), Mailbox_Init_Tracker, Receiver_Types, (Request_ID_Generator with External)),
     Initializes => (Mailboxes, Request_ID_Generator, Mailbox_Init_Tracker)
 is
    -- Definition of domain ID numbers. Domain #0 is special; it means the "current" domain.
@@ -66,7 +66,23 @@ is
       record
          Domain_ID : Domain_ID_Type := 0;
          Module_ID : Module_ID_Type := 1;
-       end record;
+      end record;
+
+   -- The union of a module ID and message ID. Forms a
+   -- unique identifier for this type of message across
+   -- all domains in this project.
+   type Universal_Message_Type is
+      record
+         Module_ID : Module_ID_Type;
+         Message_ID : Message_ID_Type;
+      end record;
+
+   -- True if the given receiving address can be sent the given message type.
+   function Receives(Receiver : Message_Address; Msg_Type : Universal_Message_Type) return Boolean
+     with Global => (Input => Receiver_Types),
+     Depends => (Receives'Result => (Receiver_Types, Receiver, Msg_Type)),
+       Pre => Module_Ready(Receiver.Module_ID);
+
    -- Messages currently have a priority field that is not used. The intention is to allow high
    -- priority messages to be processed earlier and without interruption. SPARK does not support
    -- dynamic task priorities, however, so the usefulness of this idea is questionable. We could
@@ -77,7 +93,7 @@ is
          Sender_Address : Message_Address;
          Receiver_Address : Message_Address;
          Request_ID : Request_ID_Type;
-         Message_ID : Message_ID_Type;
+         Message_Type : Universal_Message_Type;
          Priority   : System.Priority;
          Payload    : not null Data_Array_Owner;
       end record;
@@ -89,7 +105,7 @@ is
      (Sender_Address : Message_Address;
       Receiver_Address : Message_Address;
       Request_ID : Request_ID_Type;
-      Message_ID : Message_ID_Type;
+      Message_Type : Universal_Message_Type;
       Payload_Size : Natural;
       Priority   : System.Priority := System.Default_Priority) return Message_Record
      with
@@ -98,7 +114,7 @@ is
          Make_Empty_Message'Result.Sender_Address   = Sender_Address   and
          Make_Empty_Message'Result.Receiver_Address = Receiver_Address and
          Make_Empty_Message'Result.Request_ID = Request_ID and
-         Make_Empty_Message'Result.Message_ID = Message_ID and
+         Make_Empty_Message'Result.Message_Type = Message_Type and
          Make_Empty_Message'Result.Payload /= null and
          Make_Empty_Message'Result.Payload'Length = Payload_Size and
          Make_Empty_Message'Result.Priority   = Priority;
@@ -146,18 +162,28 @@ is
    -- Blocks until a message is available.
    procedure Read_Next(Box : Module_Mailbox; Msg : out Msg_Owner);
 
+   -- Count the number of messages in the mailbox waiting
+   -- to be read.
+   function Queue_Size(Box : Module_Mailbox) return Natural;
+
+   type Message_Type_Array is array (Natural range <>) of Universal_Message_Type;
+   Unchecked_Type : constant Message_Type_Array(1 .. 0) := (others => <>);
+
    -- Register a module with the mail system.
    -- Gets an observer for that module's mailbox.
+   -- If Receives is set to Unchecked_Type, there will be no
+   -- type checking on messages sent to this module.
    procedure Register_Module(Module_ID : in Module_ID_Type;
                              Msg_Queue_Size : in Positive;
-                             Mailbox : out Module_Mailbox)
-     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
+                             Mailbox : out Module_Mailbox;
+                             Receives : in Message_Type_Array)
+     with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker, Receiver_Types)),
        Depends => (Mailboxes => +(Msg_Queue_Size, Module_ID),
                    Mailbox_Init_Tracker => +(Module_ID),
-                   Mailbox => Module_ID),
+                   Mailbox => Module_ID,
+                  Receiver_Types => +(Receives, Module_ID)),
        Pre => Module_Ready(Module_ID) = False,
        Post => Module_Ready(Module_ID) = True;
-
 
    -- Definition of the array type used to hold messages in a mailbox. This needs to be here
    -- rather than in the body because Message_Count_Type is used below.
@@ -183,9 +209,10 @@ is
    -- Depreciated: Use Mailboxes to send messages
    procedure Route_Message(Message : in out Msg_Owner; Status : out Status_Type)
      with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
-     Pre => Message /= null and
-     (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID)),
-       Posr => Message = null;
+     Pre => Message /= null
+     and then (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID))
+     and then Receives(Message.Receiver_Address, Message.Message_Type),
+     Post => Message = null;
 
    -- Send the indicated message to the right mailbox. This might cross domains. This procedure
    -- returns at once. If the message could not be delivered it is lost with no indication.
@@ -193,8 +220,9 @@ is
    -- Depreciated: Use Mailboxes to send messages
    procedure Route_Message(Message : in out Msg_Owner)
      with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
-     Pre => Message /= null and
-     (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID));
+     Pre => Message /= null
+     and then (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID))
+     and then Receives(Message.Receiver_Address, Message.Message_Type);
 
    procedure Route_Message(Message : in Message_Record)
      with Global => (In_Out => (Mailboxes, Mailbox_Init_Tracker)),
@@ -205,7 +233,7 @@ is
 
 private
 
-      type Module_Mailbox is
+   type Module_Mailbox is
       record
          Address : Message_Address;
       end record;

--- a/src/modules/cubedos-interpreter-api.adb
+++ b/src/modules/cubedos-interpreter-api.adb
@@ -61,7 +61,6 @@ package body CubedOS.Interpreter.API is
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       Position := Last + 1;
 
-      -- Set the message size.
       return Message;
    end Set_Reply_Encode;
 
@@ -102,7 +101,6 @@ package body CubedOS.Interpreter.API is
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       Position := Last + 1;
 
-      -- Set the message size.
       return Message;
    end Add_Reply_Encode;
 

--- a/src/modules/cubedos-interpreter-api.adb
+++ b/src/modules/cubedos-interpreter-api.adb
@@ -18,7 +18,7 @@ package body CubedOS.Interpreter.API is
    is
       Message : constant Message_Record :=
         Make_Empty_Message
-          (Sender_Address, Name_Resolver.Interpreter, Request_ID, Message_Type'Pos(Clear_Request), Priority);
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Clear_Request)), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -32,7 +32,7 @@ package body CubedOS.Interpreter.API is
    is
       Message : constant Message_Record :=
         Make_Empty_Message
-          (Sender_Address, Name_Resolver.Interpreter, Request_ID, Message_Type'Pos(Set_Request), Priority);
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Set_Request)), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -48,7 +48,7 @@ package body CubedOS.Interpreter.API is
       -- The skeletal message knows its sender (this module).
       Message : constant Message_Record :=
         Make_Empty_Message
-          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Set_Reply), Max_Message_Size, Priority);
+          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, (This_Module, Message_Type'Pos(Set_Reply)), Max_Message_Size, Priority);
 
       Position : Data_Index_Type;
       Last     : Data_Index_Type;
@@ -72,7 +72,7 @@ package body CubedOS.Interpreter.API is
    is
       Message : constant Message_Record :=
         Make_Empty_Message
-          (Sender_Address, Name_Resolver.Interpreter, Request_ID, Message_Type'Pos(Add_Request), Priority);
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Add_Request)), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -88,7 +88,7 @@ package body CubedOS.Interpreter.API is
       -- The skeletal message knows its sender (this module).
       Message : constant Message_Record :=
         Make_Empty_Message
-          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, Message_Type'Pos(Add_Reply), Max_Message_Size, Priority);
+          (Name_Resolver.Interpreter, Receiver_Address, Request_ID, (This_Module, Message_Type'Pos(Add_Reply)), Max_Message_Size, Priority);
 
       Position : Data_Index_Type;
       Last     : Data_Index_Type;

--- a/src/modules/cubedos-interpreter-api.ads
+++ b/src/modules/cubedos-interpreter-api.ads
@@ -16,6 +16,8 @@ with System;
 
 package CubedOS.Interpreter.API is
 
+   This_Module : constant Module_ID_Type := Name_Resolver.Interpreter.Module_ID;
+
    type Status_Type is (Success, Failure);
 
    type Message_Type is
@@ -58,19 +60,19 @@ package CubedOS.Interpreter.API is
    with Global => null;
 
    function Is_Clear_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Clear_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Clear_Request)));
 
    function Is_Set_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Set_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Set_Request)));
 
    function Is_Set_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Set_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Set_Reply)));
 
    function Is_Add_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Add_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Add_Request)));
 
    function Is_Add_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.Interpreter and Message.Message_ID = Message_Type'Pos(Add_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Add_Reply)));
 
    procedure Clear_Request_Decode(Message : in  Message_Record; Decode_Status : out Message_Status_Type)
      with

--- a/src/modules/cubedos-interpreter-messages.adb
+++ b/src/modules/cubedos-interpreter-messages.adb
@@ -88,5 +88,5 @@ package body CubedOS.Interpreter.Messages is
    end Message_Loop;
 
 begin
-      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
+      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox, Unchecked_Type);
 end CubedOS.Interpreter.Messages;

--- a/src/modules/cubedos-log_server-api.adb
+++ b/src/modules/cubedos-log_server-api.adb
@@ -38,7 +38,7 @@ package body CubedOS.Log_Server.API is
           (Sender_Address   => Sender_Address,
            Receiver_Address => Name_Resolver.Log_Server,
            Request_ID       => Request_ID,
-           Message_ID       => Message_Type'Pos(Log_Text),
+           Message_Type       => (This_Module, Message_Type'Pos(Log_Text)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority         => Priority);
       Position : Data_Index_Type;

--- a/src/modules/cubedos-log_server-api.ads
+++ b/src/modules/cubedos-log_server-api.ads
@@ -15,6 +15,8 @@ with System;
 
 package CubedOS.Log_Server.API is
 
+   This_Module : constant Module_ID_Type := Name_Resolver.Log_Server.Module_ID;
+
    -- This type is not needed right now. It is intended to be used in replies to indicate success or failure
    -- of a request. However, the Log Server never sends any reply messages. Maybe later?
    -- type Status_Type is (Success, Failure);
@@ -53,7 +55,7 @@ package CubedOS.Log_Server.API is
 
 
    function Is_A_Log_Text(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Log_Server and Message.Message_ID = Message_Type'Pos(Log_Text));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Log_Text)));
 
 
    procedure Log_Text_Decode

--- a/src/modules/cubedos-log_server-messages.adb
+++ b/src/modules/cubedos-log_server-messages.adb
@@ -70,5 +70,5 @@ package body CubedOS.Log_Server.Messages is
    end Message_Loop;
 
 begin
-      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
+      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox, Unchecked_Type);
 end CubedOS.Log_Server.Messages;

--- a/src/modules/cubedos-publish_subscribe_server-api.adb
+++ b/src/modules/cubedos-publish_subscribe_server-api.adb
@@ -28,7 +28,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address   => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Subscribe_Request),
+           Message_Type => (This_Module, Message_Type'Pos(Subscribe_Request)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
@@ -52,7 +52,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Subscribe_Reply),
+           Message_Type => (This_Module, Message_Type'Pos(Subscribe_Reply)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
@@ -77,7 +77,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Unsubscribe_Request),
+           Message_Type => (This_Module, Message_Type'Pos(Unsubscribe_Request)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
@@ -101,7 +101,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Unsubscribe_Reply),
+           Message_Type => (This_Module, Message_Type'Pos(Unsubscribe_Reply)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
@@ -127,7 +127,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Publish_Request),
+           Message_Type => (This_Module, Message_Type'Pos(Publish_Request)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
@@ -155,7 +155,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Publish_Reply),
+           Message_Type => (This_Module, Message_Type'Pos(Publish_Reply)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;
@@ -181,7 +181,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
           (Sender_Address => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
            Request_ID => Request_ID,
-           Message_ID => Message_Type'Pos(Publish_Result),
+           Message_Type => (This_Module, Message_Type'Pos(Publish_Result)),
            Payload_Size => Message_Manager.Max_Message_Size,
            Priority   => Priority);
       Position : XDR_Index_Type;

--- a/src/modules/cubedos-publish_subscribe_server-api.ads
+++ b/src/modules/cubedos-publish_subscribe_server-api.ads
@@ -16,6 +16,8 @@ with System;
 
 package CubedOS.Publish_Subscribe_Server.API is
 
+   This_Module : constant Module_ID_Type := Name_Resolver.Publish_Subscribe_Server.Module_ID;
+
    type Status_Type is (Success, Failure);
    type Channel_ID_Type is range 1 .. 16;
 
@@ -88,25 +90,25 @@ package CubedOS.Publish_Subscribe_Server.API is
 
 
    function Is_Subscribe_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Subscribe_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Subscribe_Request)));
 
    function Is_Subscribe_Reply(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Subscribe_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Subscribe_Reply)));
 
    function Is_Unsubscribe_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Unsubscribe_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Unsubscribe_Request)));
 
    function Is_Unsubscribe_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Unsubscribe_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Unsubscribe_Reply)));
 
    function Is_Publish_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Publish_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Publish_Request)));
 
    function Is_Publish_Reply(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Publish_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Publish_Reply)));
 
    function Is_Publish_Result(Message : in Message_Record) return Boolean is
-     (Message.Sender_Address = Name_Resolver.Publish_Subscribe_Server and Message.Message_ID = Message_Type'Pos(Publish_Result));
+     (Message.Message_Type = (This_Module, Message_Type'Pos(Publish_Result)));
 
 
    procedure Subscribe_Request_Decode

--- a/src/modules/cubedos-publish_subscribe_server-messages.adb
+++ b/src/modules/cubedos-publish_subscribe_server-messages.adb
@@ -136,5 +136,5 @@ is
    end Message_Loop;
 
 begin
-      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
+      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox, Unchecked_Type);
 end CubedOS.Publish_Subscribe_Server.Messages;

--- a/src/modules/cubedos-time_server-api.adb
+++ b/src/modules/cubedos-time_server-api.adb
@@ -25,19 +25,17 @@ package body CubedOS.Time_Server.API is
       Series_ID      : in Series_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message    : Message_Record;
-      Position   : Data_Index_Type;
-      Last       : Data_Index_Type;
-      Interval   : constant Duration := Ada.Real_Time.To_Duration(Tick_Interval);
-   begin
-      Message := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address   => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Relative_Request),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
-
+      Position   : Data_Index_Type;
+      Last       : Data_Index_Type;
+      Interval   : constant Duration := Ada.Real_Time.To_Duration(Tick_Interval);
+   begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(1000*Interval), Message.Payload.all, Position, Last);
       Position := Last + 1;
@@ -55,20 +53,18 @@ package body CubedOS.Time_Server.API is
       Series_ID      : in Series_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message    : Message_Record;
-      Position   : Data_Index_Type;
-      Last       : Data_Index_Type;
-      Seconds    : Ada.Real_Time.Seconds_Count;
-      Fraction   : Ada.Real_Time.Time_Span;
-   begin
-      Message := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Absolute_Request),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
-
+      Position   : Data_Index_Type;
+      Last       : Data_Index_Type;
+      Seconds    : Ada.Real_Time.Seconds_Count;
+      Fraction   : Ada.Real_Time.Time_Span;
+   begin
       Ada.Real_Time.Split(Tick_Time, Seconds, Fraction);
 
       Position := 0;
@@ -113,18 +109,16 @@ package body CubedOS.Time_Server.API is
       Series_ID      : in Series_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message    : Message_Record;
-      Position   : Data_Index_Type;
-      Last       : Data_Index_Type;
-   begin
-      Message := Make_Empty_Message
+      Message : constant Message_Record := Make_Empty_Message
         (Sender_Address   => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
          Message_ID => Message_Type'Pos(Cancel_Request),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
-
+      Position   : Data_Index_Type;
+      Last       : Data_Index_Type;
+   begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(Series_ID), Message.Payload.all, Position, Last);
       return message;

--- a/src/modules/cubedos-time_server-api.adb
+++ b/src/modules/cubedos-time_server-api.adb
@@ -29,7 +29,7 @@ package body CubedOS.Time_Server.API is
         (Sender_Address   => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Relative_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Relative_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
       Position   : Data_Index_Type;
@@ -57,7 +57,7 @@ package body CubedOS.Time_Server.API is
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Absolute_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Absolute_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
       Position   : Data_Index_Type;
@@ -86,7 +86,7 @@ package body CubedOS.Time_Server.API is
         (Sender_Address   => Name_Resolver.Time_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Tick_Reply),
+         Message_Type => (This_Module, Message_Type'Pos(Tick_Reply)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
 
@@ -113,7 +113,7 @@ package body CubedOS.Time_Server.API is
         (Sender_Address   => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
-         Message_ID => Message_Type'Pos(Cancel_Request),
+         Message_Type => (This_Module, Message_Type'Pos(Cancel_Request)),
          Payload_Size => Message_Manager.Max_Message_Size,
          Priority   => Priority);
       Position   : Data_Index_Type;

--- a/src/modules/cubedos-time_server-api.ads
+++ b/src/modules/cubedos-time_server-api.ads
@@ -18,6 +18,8 @@ use Message_Manager;
 
 package CubedOS.Time_Server.API is
 
+   This_Module : constant Module_ID_Type := Name_Resolver.Time_Server.Module_ID;
+
    -- Specifies the kinds of messages that can be sent to or received from the tick generator.
    -- @value Relative_Request A request for a tick using a time relative to when the request
    --   is made (e. g., "5 seconds from now").
@@ -100,16 +102,16 @@ package CubedOS.Time_Server.API is
      with Global => null;
 
    function Is_Relative_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Relative_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos (Relative_Request)));
 
    function Is_Absolute_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Absolute_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos (Absolute_Request)));
 
    function Is_Tick_Reply(Message : in Message_Record) return Boolean is
-      (Message.Sender_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Tick_Reply));
+     (Message.Message_Type = (This_Module, Message_Type'Pos (Tick_Reply)));
 
    function Is_Cancel_Request(Message : in Message_Record) return Boolean is
-     (Message.Receiver_Address = Name_Resolver.Time_Server and Message.Message_ID = Message_Type'Pos (Cancel_Request));
+     (Message.Message_Type = (This_Module, Message_Type'Pos (Cancel_Request)));
 
    -- Decode Relative_Request messages. See Relative_Request_Encode for information about the
    -- parameters.

--- a/src/modules/cubedos-time_server-messages.adb
+++ b/src/modules/cubedos-time_server-messages.adb
@@ -280,5 +280,5 @@ is
    end Message_Loop;
 
 begin
-      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox);
+      Message_Manager.Register_Module(Name_Resolver.File_Server.Module_ID, 8, Mailbox, Unchecked_Type);
 end CubedOS.Time_Server.Messages;


### PR DESCRIPTION

All messages now have a message type. Modules must statically
declare what message types they may receive. Unreceivable message
types are checked for when a message is sent. Current behavior when
finding an unacceptable message type is crashing.

To make this commit smaller, I added an "Unchecked_Type" which
modules can pass when registering themselves to avoid specifying
their types. I will remove this in future commits.

I went through all the API files and added the message type to all
encoder and message type checker functions.

In this commit, I slightly change how Module IDs are used. A module
ID now refers to a type of module, with the thought being that one
module type may be present in multiple domains. This resolves an
ambiguity in how messages type is inferred in the inter-domain case.

More can be read about this decision immediately in the Eric's Notes
document and later when I write a proper rational for this refactor.
Merc will need minor modifications to generate the appropriate API
files.

Note that it is not yet possible to formally prove messages will
be send to acceptable receivers. I also still haven't SPARK proved
any of this refactor.

I've also added a test to verify the message system is filtering
messages appropriately. It is now possible for receiving modules
which specify appropriate message types to receive to stop
checking for unacceptable messages.