### PR TITLE
Make Message_Record Immutable

### DIFF
--- a/src/check/check_message_passing.adb
+++ b/src/check/check_message_passing.adb
@@ -19,10 +19,10 @@ package body Check_Message_Passing is
       Sender_Addr : constant Message_Address := (0, 1);
       Receiver_Addr : constant Message_Address := (0, 2);
 
-      Unacceptable_Msg : constant Message_Record := Make_Empty_Message
-        (Sender_Addr, Receiver_Addr, 0, Unnacceptable_Type, 0);
-      Acceptable_Msg : constant Message_Record := Make_Empty_Message
-        (Sender_Addr, Receiver_Addr, 0, Acceptable_Type, 0);
+      Unacceptable_Msg : constant Message_Record := Immutable(Make_Empty_Message
+        (Sender_Addr, Receiver_Addr, 0, Unnacceptable_Type, 0));
+      Acceptable_Msg : constant Message_Record := Immutable(Make_Empty_Message
+        (Sender_Addr, Receiver_Addr, 0, Acceptable_Type, 0));
 
       Sender : Module_Mailbox;
       Receiver : Module_Mailbox;

--- a/src/check/main_message_manager.adb
+++ b/src/check/main_message_manager.adb
@@ -5,9 +5,13 @@ use Ada.Text_IO;
 use Message_Manager;
 
 procedure Main_Message_Manager is
+   Message, Message_2, Message_3, Message_4, Message_5, Message_6 : Mutable_Message_Record
+     := Make_Empty_Message((1, 1), (1, 1), 0, (1, 1), 0);
 
-   Message, Message_2, Message_3, Message_4, Message_5, Message_6 : Message_Manager.Msg_Owner
-     := new Message_Record'(Make_Empty_Message((1, 1), (1, 1), 0, (1, 1), 0));
+   -- This message stores received messages while they're printed
+   -- It's value can be discarded whenever.
+   Temp_Msg : Msg_Owner := null;
+
    Message_Type : constant Message_Manager.Universal_Message_Type := (1, 1);
    Message_Type_2 : constant Message_Manager.Universal_Message_Type := (1, 2);
    Message_Status : Message_Manager.Status_Type;
@@ -20,9 +24,9 @@ procedure Main_Message_Manager is
       Put_Line("+++++ FETCHING MESSAGES FOR RECIEVER ID = 1 +++++");
       New_Line;
       while Y < 9 loop
-         Message_Manager.Read_Next(Mailbox_1, Message);
+         Message_Manager.Read_Next(Mailbox_1, Temp_Msg);
          Put_Line("Message " & Integer'Image(Y) & " fetched ");
-         Put_Line(Message_Manager.Stringify_Message(Message.all));
+         Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
          New_Line;
 
          Y := Y + 1;
@@ -37,9 +41,9 @@ procedure Main_Message_Manager is
       Put_Line("+++++ FETCHING MESSAGES FOR RECIEVER ID = 2 +++++");
       New_Line;
       while Y < 9 loop
-         Message_Manager.Read_Next(Mailbox_2, Message_5);
+         Message_Manager.Read_Next(Mailbox_2, Temp_Msg);
          Put_Line("Message " & Integer'Image(Y) & " fetched ");
-         Put_Line(Message_Manager.Stringify_Message(Message.all));
+         Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
          New_Line;
 
          Y := Y + 1;
@@ -71,37 +75,37 @@ begin
    New_Line(2);
 
    -- Test Make_Empty_Message
-   Message_3 := new Message_Record'(Make_Empty_Message
+   Message_3 := Make_Empty_Message
      (Sender_Address   => (0, 2),
       Receiver_Address => (0, 1),
       Request_ID       => 4,
       Message_Type     => Message_Type,
       Payload_Size     => 0,
-      Priority         => 2));
+      Priority         => 2);
 
-   Message_4 := new Message_Record'(Make_Empty_Message
+   Message_4 := Make_Empty_Message
      (Sender_Address   => (1, 1),
       Receiver_Address => (1, 2),
       Request_ID       => 8,
       Message_Type       => Message_Type_2,
       Payload_Size     => 0,
-      Priority         => 5));
+      Priority         => 5);
 
-   Message_5 := new Message_Record'(Make_Empty_Message
+   Message_5 := Make_Empty_Message
      (Sender_Address   => (2, 2),
       Receiver_Address => (1, 2),
       Request_ID       => 1,
       Message_Type       => Message_Type,
       Payload_Size     => 0,
-      Priority         => 1));
+      Priority         => 1);
 
-   Message_6 := new Message_Record'(Make_Empty_Message
+   Message_6 := Make_Empty_Message
      (Sender_Address   => (1, 2),
       Receiver_Address => (1, 2),
       Request_ID       => 1,
       Message_Type       => Message_Type_2,
       Payload_Size     => 0,
-      Priority         => 4));
+      Priority         => 4);
 
 
    -- 20 messages should be attempted to be sent, only first eight should be sent
@@ -110,55 +114,55 @@ begin
    while X < 40 loop
       -- Ensure the Make_Empty_Message works properly
       if X = 12 or X = 31 then
-         Route_Message(Message => Message_3.all, Status => Message_Status);
+         Route_Message(Message => Immutable(Message_3), Status => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line(Message_Manager.Stringify_Message(Message.all));
+         Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
          New_Line;
          X := X + 1;
 
       elsif X = 15 or X = 22 then
-         Route_Message(Message => Message_4.all, Status  => Message_Status);
+         Route_Message(Message => Immutable(Message_4), Status  => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line(Message_Manager.Stringify_Message(Message.all));
+         Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
          New_Line;
          X := X + 1;
 
       elsif X = 11 or X = 28 then
-         Route_Message(Message => Message_5.all, Status  => Message_Status);
+         Route_Message(Message => Immutable(Message_5), Status  => Message_Status);
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line(Message_Manager.Stringify_Message(Message.all));
+         Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
          New_Line;
          X := X + 1;
 
 
       elsif X = 4 or X = 23 then
          -- Test Route_Message without status parameter
-         Route_Message(Message => Message_2.all);
+         Route_Message(Message => Immutable(Message_2));
          Put_Line("Message" & Integer'Image(X) & " routed");
          Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-         Put_Line(Message_Manager.Stringify_Message(Message.all));
+         Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
          New_Line;
          X := X + 1;
 
       else
          -- Testing Route_Message with Status parameter
          if X < 22 then
-            Route_Message(Message => Message.all, Status => Message_Status);
+            Route_Message(Message => Immutable(Message), Status => Message_Status);
             Put_Line("Message" & Integer'Image(X) & " routed");
             Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-            Put_Line(Message_Manager.Stringify_Message(Message.all));
+            Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
             New_Line;
             X := X + 1;
          end if;
 
          if X > 20 then
-            Route_Message(Message => Message_6.all, Status => Message_Status);
+            Route_Message(Message => Immutable(Message_6), Status => Message_Status);
             Put_Line("Message" & Integer'Image(X) & " routed");
             Put_Line("+++ Status      : " & Status_Type'Image(Message_Status));
-            Put_Line(Message_Manager.Stringify_Message(Message.all));
+            Put_Line(Message_Manager.Stringify_Message(Temp_Msg.all));
             New_Line;
             X := X + 1;
          end if;

--- a/src/modules/cubedos-file_server-api.adb
+++ b/src/modules/cubedos-file_server-api.adb
@@ -23,7 +23,7 @@ package body CubedOS.File_Server.API is
       Name           : in String;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
@@ -40,7 +40,7 @@ package body CubedOS.File_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Name'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(Name, Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Open_Request_Encode;
 
 
@@ -51,7 +51,7 @@ package body CubedOS.File_Server.API is
       Handle           : in API.File_Handle_Type;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
@@ -64,7 +64,7 @@ package body CubedOS.File_Server.API is
    begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Open_Reply_Encode;
 
 
@@ -75,7 +75,7 @@ package body CubedOS.File_Server.API is
       Amount         : in Read_Size_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
@@ -90,7 +90,7 @@ package body CubedOS.File_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Read_Request_Encode;
 
 
@@ -103,7 +103,7 @@ package body CubedOS.File_Server.API is
       Data             : in Octet_Array;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
@@ -120,7 +120,7 @@ package body CubedOS.File_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(Data(Data'First ..  Data'First + (Amount - 1)), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Read_Reply_Encode;
 
 
@@ -132,7 +132,7 @@ package body CubedOS.File_Server.API is
       Data           : in Octet_Array;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
@@ -149,7 +149,7 @@ package body CubedOS.File_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(Data(Data'First .. Data'First + (Amount - 1)), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Write_Request_Encode;
 
 
@@ -161,7 +161,7 @@ package body CubedOS.File_Server.API is
       Amount           : in Write_Result_Size_Type;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Name_Resolver.File_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
@@ -176,7 +176,7 @@ package body CubedOS.File_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Amount), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Write_Reply_Encode;
 
 
@@ -186,7 +186,7 @@ package body CubedOS.File_Server.API is
       Handle         : in Valid_File_Handle_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.File_Server,
          Request_ID => Request_ID,
@@ -199,7 +199,7 @@ package body CubedOS.File_Server.API is
    begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(Handle), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Close_Request_Encode;
 
    -- Decodes:

--- a/src/modules/cubedos-generic_message_manager.adb
+++ b/src/modules/cubedos-generic_message_manager.adb
@@ -148,12 +148,26 @@ is
 
    end Sync_Mailbox;
 
+   ----------------------
+   -- Immutable Messages
+   ----------------------
+
+   function Immutable(Msg : Mutable_Message_Record) return Message_Record is
+      (Msg.Sender_Address, Msg.Receiver_Address, Msg.Request_ID, Msg.Message_Type, Msg.Priority, Msg.Payload);
+
+   function Sender_Address(Msg : Message_Record) return Message_Address is (Msg.Sender_Address);
+   function Receiver_Address(Msg : Message_Record) return Message_Address is (Msg.Receiver_Address);
+   function Request_ID(Msg : Message_Record) return Request_ID_Type is (Msg.Request_ID);
+   function Message_Type(Msg : Message_Record) return Universal_Message_Type is (Msg.Message_Type);
+   function Priority(Msg : Message_Record) return System.Priority is (Msg.Priority);
+   function Payload(Msg : Message_Record) return not null access constant Data_Array is (Msg.Payload);
+
    function Make_Empty_Message
      (Sender_Address : Message_Address; Receiver_Address : Message_Address;
       Request_ID     : Request_ID_Type; Message_Type : Universal_Message_Type;
       Payload_Size : Natural;
       Priority       : System.Priority := System.Default_Priority)
-      return Message_Record
+      return Mutable_Message_Record
    is
       subtype Definite_Data_Array is Data_Array(0 .. Payload_Size - 1);
    begin

--- a/src/modules/cubedos-generic_message_manager.ads
+++ b/src/modules/cubedos-generic_message_manager.ads
@@ -88,7 +88,7 @@ is
    -- dynamic task priorities, however, so the usefulness of this idea is questionable. We could
    -- still sort mailboxes by message priority (not currently done) which might be a little
    -- useful.
-   type Message_Record is
+   type Mutable_Message_Record is
       record
          Sender_Address : Message_Address;
          Receiver_Address : Message_Address;
@@ -98,7 +98,22 @@ is
          Payload    : not null Data_Array_Owner;
       end record;
 
+   -- Immutible version of message record
+   type Message_Record is tagged private;
    type Msg_Owner is access Message_Record;
+   -- Creates an immutible copy of the given message
+   function Immutable(Msg : Mutable_Message_Record) return Message_Record;
+
+   function Sender_Address(Msg : Message_Record) return Message_Address;
+   function Receiver_Address(Msg : Message_Record) return Message_Address;
+   function Request_ID(Msg : Message_Record) return Request_ID_Type;
+   function Message_Type(Msg : Message_Record) return Universal_Message_Type;
+   function Priority(Msg : Message_Record) return System.Priority;
+   function Payload(Msg : Message_Record) return not null access constant Data_Array;
+
+
+
+
 
    -- Convenience constructor function for messages. This is used by encoding functions.
    function Make_Empty_Message
@@ -107,7 +122,7 @@ is
       Request_ID : Request_ID_Type;
       Message_Type : Universal_Message_Type;
       Payload_Size : Natural;
-      Priority   : System.Priority := System.Default_Priority) return Message_Record
+      Priority   : System.Priority := System.Default_Priority) return Mutable_Message_Record
      with
        Global => null,
        Post=>
@@ -232,6 +247,15 @@ is
        Pre => (if Message.Receiver_Address.Domain_ID = Domain_ID then Module_Ready(Message.Receiver_Address.Module_ID));
 
 private
+   type Message_Record is tagged
+      record
+         Sender_Address : Message_Address;
+         Receiver_Address : Message_Address;
+         Request_ID : Request_ID_Type;
+         Message_Type : Universal_Message_Type;
+         Priority   : System.Priority;
+         Payload    : not null Data_Array_Owner;
+      end record;
 
    type Module_Mailbox is
       record

--- a/src/modules/cubedos-interpreter-api.adb
+++ b/src/modules/cubedos-interpreter-api.adb
@@ -17,8 +17,8 @@ package body CubedOS.Interpreter.API is
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message : constant Message_Record :=
-        Make_Empty_Message
-          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Clear_Request)), Priority);
+        Immutable(Make_Empty_Message
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Clear_Request)), Priority));
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -31,8 +31,8 @@ package body CubedOS.Interpreter.API is
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
       Message : constant Message_Record :=
-        Make_Empty_Message
-          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Set_Request)), Priority);
+        Immutable(Make_Empty_Message
+          (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Set_Request)), Priority));
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
       return Message;
@@ -46,7 +46,7 @@ package body CubedOS.Interpreter.API is
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
       -- The skeletal message knows its sender (this module).
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Name_Resolver.Interpreter, Receiver_Address, Request_ID, (This_Module, Message_Type'Pos(Set_Reply)), Max_Message_Size, Priority);
 
@@ -61,7 +61,7 @@ package body CubedOS.Interpreter.API is
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       Position := Last + 1;
 
-      return Message;
+      return Immutable(Message);
    end Set_Reply_Encode;
 
 
@@ -70,12 +70,12 @@ package body CubedOS.Interpreter.API is
       Request_ID     : in Request_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address, Name_Resolver.Interpreter, Request_ID, (This_Module, Message_Type'Pos(Add_Request)), Priority);
    begin
       -- Fill in the message by encoding the other parameters (not shown) as required.
-      return Message;
+      return Immutable(Message);
    end Add_Request_Encode;
 
 
@@ -86,7 +86,7 @@ package body CubedOS.Interpreter.API is
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
       -- The skeletal message knows its sender (this module).
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Name_Resolver.Interpreter, Receiver_Address, Request_ID, (This_Module, Message_Type'Pos(Add_Reply)), Max_Message_Size, Priority);
 
@@ -101,7 +101,7 @@ package body CubedOS.Interpreter.API is
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
       Position := Last + 1;
 
-      return Message;
+      return Immutable(Message);
    end Add_Reply_Encode;
 
 

--- a/src/modules/cubedos-log_server-api.adb
+++ b/src/modules/cubedos-log_server-api.adb
@@ -33,7 +33,7 @@ package body CubedOS.Log_Server.API is
       Text           : in String;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Sender_Address,
            Receiver_Address => Name_Resolver.Log_Server,
@@ -50,7 +50,7 @@ package body CubedOS.Log_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Text'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(Text, Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Log_Text_Encode;
 
 

--- a/src/modules/cubedos-publish_subscribe_server-api.adb
+++ b/src/modules/cubedos-publish_subscribe_server-api.adb
@@ -23,7 +23,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Channel    : in Channel_ID_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
@@ -36,7 +36,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
    begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Subscribe_Request_Encode;
 
 
@@ -47,7 +47,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status     : in Status_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
@@ -62,7 +62,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Subscribe_Reply_Encode;
 
 
@@ -72,7 +72,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Channel        : in Channel_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
@@ -85,7 +85,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
    begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Unsubscribe_Request_Encode;
 
 
@@ -96,7 +96,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status     : in Status_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
@@ -111,7 +111,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Unsubscribe_Reply_Encode;
 
 
@@ -122,7 +122,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Message_Data : in CubedOS.Lib.Octet_Array;
       Priority     : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address => Sender_Address,
            Receiver_Address => Name_Resolver.Publish_Subscribe_Server,
@@ -139,7 +139,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Message_Data'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(Message_Data, Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Publish_Request_Encode;
 
 
@@ -150,7 +150,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Status     : in Status_Type;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address   => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
@@ -165,7 +165,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Channel), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Status_Type'Pos(Status)), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Publish_Reply_Encode;
 
 
@@ -176,7 +176,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       Message_Data : in CubedOS.Lib.Octet_Array;
       Priority   : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record :=
+      Message : constant Mutable_Message_Record :=
         Make_Empty_Message
           (Sender_Address => Name_Resolver.Publish_Subscribe_Server,
            Receiver_Address => Receiver_Address,
@@ -193,7 +193,7 @@ package body CubedOS.Publish_Subscribe_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Message_Data'Length), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(Message_Data, Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Publish_Result_Encode;
 
 

--- a/src/modules/cubedos-time_server-api.adb
+++ b/src/modules/cubedos-time_server-api.adb
@@ -25,7 +25,7 @@ package body CubedOS.Time_Server.API is
       Series_ID      : in Series_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address   => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
@@ -42,7 +42,7 @@ package body CubedOS.Time_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Series_Type'Pos(Request_Type)), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Series_ID), Message.Payload.all, Position, Last);
-      return Message;
+      return Immutable(Message);
    end Relative_Request_Encode;
 
 
@@ -53,7 +53,7 @@ package body CubedOS.Time_Server.API is
       Series_ID      : in Series_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
@@ -71,7 +71,7 @@ package body CubedOS.Time_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Seconds), Message.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Series_ID), Message.Payload.all, Position, Last);
-      return message;
+      return Immutable(Message);
    end Absolute_Request_Encode;
 
 
@@ -82,7 +82,7 @@ package body CubedOS.Time_Server.API is
       Count            : in Series_Count_Type;
       Priority         : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Result : constant Message_Record := Make_Empty_Message
+      Result : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address   => Name_Resolver.Time_Server,
          Receiver_Address => Receiver_Address,
          Request_ID => Request_ID,
@@ -99,7 +99,7 @@ package body CubedOS.Time_Server.API is
       XDR.Encode(XDR.XDR_Unsigned(Series_ID), Result.Payload.all, Position, Last);
       Position := Last + 1;
       XDR.Encode(XDR.XDR_Unsigned(Count), Result.Payload.all, Position, Last);
-      return Result;
+      return Immutable(Result);
    end Tick_Reply_Encode;
 
 
@@ -109,7 +109,7 @@ package body CubedOS.Time_Server.API is
       Series_ID      : in Series_ID_Type;
       Priority       : in System.Priority := System.Default_Priority) return Message_Record
    is
-      Message : constant Message_Record := Make_Empty_Message
+      Message : constant Mutable_Message_Record := Make_Empty_Message
         (Sender_Address   => Sender_Address,
          Receiver_Address => Name_Resolver.Time_Server,
          Request_ID => Request_ID,
@@ -121,7 +121,7 @@ package body CubedOS.Time_Server.API is
    begin
       Position := 0;
       XDR.Encode(XDR.XDR_Unsigned(Series_ID), Message.Payload.all, Position, Last);
-      return message;
+      return Immutable(Message);
    end Cancel_Request_Encode;
 
 

--- a/src/modules/cubedos-transport_udp-messages.adb
+++ b/src/modules/cubedos-transport_udp-messages.adb
@@ -15,14 +15,14 @@ use  CubedOS.Lib;
 
 package body CubedOS.Transport_UDP.Messages is
 
-   function Read_Stream_Message ( Data : Ada.Streams.Stream_Element_Array; Last : Ada.Streams.Stream_Element_Offset) return Message_Manager.Message_Record is
+   function Read_Stream_Message ( Data : Ada.Streams.Stream_Element_Array; Last : Ada.Streams.Stream_Element_Offset) return Message_Manager.Mutible_Message_Record is
       Sender_Domain : Message_Manager.Domain_ID_Type;
       Sender_Module : Message_Manager.Module_ID_Type;
       Receiver_Domain : Message_Manager.Domain_ID_Type;
       Receiver_Module :Message_Manager. Module_ID_Type;
       Request_ID : Message_Manager.Request_ID_Type;
       Message_ID : Message_Manager.Message_ID_Type;
-      Message : Message_Manager.Message_Record;
+      Message : Message_Manager.Mutible_Message_Record;
    begin
 
       Sender_Domain := Message_Manager.Domain_ID_Type(Data(0));
@@ -61,7 +61,7 @@ package body CubedOS.Transport_UDP.Messages is
       loop
          begin
             GNAT.Sockets.Receive_Socket (Server, Data, Last, From);
-            Message := new Message_Manager.Message_Record'(Read_Stream_Message(Data, Last));
+            Message := new Message_Manager.Mutible_Message_Record'(Read_Stream_Message(Data, Last));
             Ada.Text_IO.Put_Line ("from : " & Image (From.Addr));
             if Message.Sender_Address.Domain_ID = Message_Manager.Domain_ID then
                Ada.Text_IO.Put_Line ("This message was sent from this domain! Dropping Message");
@@ -76,7 +76,7 @@ package body CubedOS.Transport_UDP.Messages is
       end loop;
    end Server_Loop;
 
-   procedure Send_Network_Message(Message : in Message_Manager.Message_Record )is
+   procedure Send_Network_Message(Message : in Message_Manager.Mutible_Message_Record )is
       Address : Sock_Addr_Type;
       Socket : Socket_Type;
       Last : Ada.Streams.Stream_Element_Offset;
@@ -109,7 +109,7 @@ package body CubedOS.Transport_UDP.Messages is
       Send_Socket (Socket, Buffer, Last, Address);
    end Send_Network_Message;
 
-   procedure Process(Message : in Message_Manager.Message_Record) is
+   procedure Process(Message : in Message_Manager.Mutible_Message_Record) is
    begin
       -- should there be some check here?
       Send_Network_Message(Message);


### PR DESCRIPTION
There are now two message record types:
- Message_Record is a private record with getters to immutable versions of all the record's components. This is what's passed around by modules and the message system.
- Mutable_Message_Record is a public record that is mutable. It can be turned into a Message_Record with the "Immutable" function.

This change prevents modules from modifying message data directly. The message manager is still able to modify Message_Record as it sees fit- Message_Record is only immutable to users.

API encoder/decoder/check functions should all use only Message_Record in their public API. Privately, they may use Mutable_Message_Record for convenience.

Note that I have now completely broken the main_message_manager.adb test file. There isn't any documentation explaining what it does and it's really unclear how it works. The way it manipulates messages is contrary to this refactor and I believe it will be easier to rewrite it from scratch than adapt it.