### PR TITLE
Add SPARK Bounded Queue implementation

### DIFF
--- a/src/check/check_bounded_queue.adb
+++ b/src/check/check_bounded_queue.adb
@@ -1,0 +1,97 @@
+---------------------------------------------------------------------------
+-- FILE    : check_bounded_queue.adb
+-- SUBJECT : Package containing tests of bounded queue.
+-- AUTHOR  : (C) Copyright 2023 by Vermont Technical College
+---------------------------------------------------------------------------
+with AUnit.Assertions; use AUnit.Assertions;
+with CubedOS.Lib.Bounded_Queues;
+
+package body Check_Bounded_Queue is
+
+   package Bool_Queues is new CubedOS.Lib.Bounded_Queues(Boolean);
+   Queue1 : Bool_Queues.Bounded_Queue := Bool_Queues.Make(3);
+   use Bool_Queues;
+   type Bool_Owner is access Boolean;
+   Bool : Data_Owner := new Boolean'(False);
+   Bool_False : constant Data_Owner := new Boolean'(False);
+   Bool_True : constant Data_Owner := new Boolean'(True);
+   procedure Take_Next is
+   begin
+      Bool := null;
+      Bool_Queues.Next(Queue1, Bool);
+   end Take_Next;
+
+   procedure Put_Another is
+      Value : Data_Owner := new Boolean'(True);
+   begin
+      Put(Queue1, Value);
+   end Put_Another;
+
+   -- Make some instantiations in SPARK
+   procedure SPARK_Inits
+     with SPARK_Mode => On
+   is
+      package Bool_Queues is new CubedOS.Lib.Bounded_Queues(Boolean);
+   begin
+      null;
+   end SPARK_Inits;
+
+
+   procedure Test_Queue(T : in out AUnit.Test_Cases.Test_Case'Class) is
+      False_Value : Data_Owner := new Boolean'(False);
+   begin
+
+      Assert(Size(Queue1) = 3, "Created queue with wrong size");
+      Assert(Count(Queue1) = 0, "Created queue with elements");
+
+      Assert_Exception(Take_Next'Access, "Queue allowed user to take nonexistant element");
+
+      Put(Queue1, False_Value); -- The first element out should be False
+
+      Assert(Count(Queue1) = 1, "Failed to add element");
+
+      Put_Another; -- The next two elements are True
+      Put_Another;
+
+      Assert_Exception(Put_Another'Access, "Queue took element even though it is full");
+
+      Assert(Count(Queue1) = Size(Queue1), "When queue is full, count should equal size");
+      Assert(Size(Queue1) = 3, "Queue size changed");
+
+      Next(Queue1, Bool);
+      Assert(Bool.all = False, "Queue fetched eroneous element 1");
+      Bool := null;
+      Next(Queue1, Bool);
+      Assert(Bool.all = True, "Queue fetched eroneous element 2");
+      Bool := null;
+
+      Assert(Count(Queue1) = 1, "Queue failed to remove elements");
+
+      Next(Queue1, Bool);
+      Bool := null;
+      Assert_Exception(Take_Next'Access, "Queue allowed user to take nonexistant element");
+
+      -- Now add two more so the queue has to wrap around its array
+      Put_Another;
+      Put_Another;
+      Put_Another;
+
+      Assert(Count(Queue1) = Size(Queue1), "When queue is full, count should equal size");
+      Assert(Size(Queue1) = 3, "Queue size changed");
+
+   end Test_Queue;
+
+
+   procedure Register_Tests(T : in out Queue_Test) is
+   begin
+      AUnit.Test_Cases.Registration.Register_Routine(T, Test_Queue'Access, "Test_Bounded_Queue");
+   end Register_Tests;
+
+
+   function Name(T : in Queue_Test) return AUnit.Message_String is
+      pragma Unreferenced(T);
+   begin
+      return AUnit.Format("Bounded Queue");
+   end Name;
+
+end Check_Bounded_Queue;

--- a/src/check/check_bounded_queue.ads
+++ b/src/check/check_bounded_queue.ads
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------------
+-- FILE    : check_bounded_queue.ads
+-- SUBJECT : Package containing tests the bounded queue.
+-- AUTHOR  : (C) Copyright 2023 by Vermont Technical College
+---------------------------------------------------------------------------
+with AUnit;
+with AUnit.Test_Cases;
+
+package Check_Bounded_Queue is
+
+   type Queue_Test is new AUnit.Test_Cases.Test_Case with null record;
+
+   procedure Register_Tests(T : in out Queue_Test);
+   function Name(T : in Queue_Test) return AUnit.Message_String;
+
+end Check_Bounded_Queue;

--- a/src/check/cubedlib_suite.adb
+++ b/src/check/cubedlib_suite.adb
@@ -14,6 +14,7 @@ with CubedOS.Lib.Bounded_Strings.Check;
 with Check_Trivial;
 with Check_Lib_CRC;
 with Check_Lib_XDR;
+with Check_Bounded_Queue;
 
 package body CubedLib_Suite is
    use AUnit.Test_Suites;
@@ -28,6 +29,7 @@ package body CubedLib_Suite is
    Test_1 : aliased Check_Lib_CRC.Lib_CRC_Test;
    Test_2 : aliased Check_Lib_XDR.Lib_XDR_Test;
    Test_3 : aliased CubedOS.Lib.Bounded_Strings.Check.Lib_Bounded_Strings_Test;
+   Test_4 : aliased Check_Bounded_Queue.Queue_Test;
 
    -- Function to return an access to the configured suite
    function Suite return Access_Test_Suite is
@@ -36,6 +38,7 @@ package body CubedLib_Suite is
       Add_Test(Suite_Object'Access, Test_1'Access);
       Add_Test(Suite_Object'Access, Test_2'Access);
       Add_Test(Suite_Object'Access, Test_3'Access);
+      Add_Test(Suite_Object'Access, Test_4'Access);
       return Suite_Object'Access;
    end Suite;
 

--- a/src/library/cubedos-lib-bounded_queues.adb
+++ b/src/library/cubedos-lib-bounded_queues.adb
@@ -1,0 +1,62 @@
+--------------------------------------------------------------------------------
+-- FILE   : cubedos-lib-bounded_queues.adb
+-- SUBJECT: Implementation of a package serving as a parent to the CubedOS runtime library.
+-- AUTHOR : (C) Copyright 2023 by Vermont Technical College
+--------------------------------------------------------------------------------
+pragma SPARK_Mode(On);
+
+package body CubedOS.Lib.Bounded_Queues is
+
+   procedure Move(Src : in out Data_Owner; Dest : in out Data_Owner)
+     with Pre => Src /= null and Dest = null,
+     Post => Src = null and Dest /= null
+   is
+   begin
+      Dest := Src;
+      Src := null;
+   end Move;
+
+   --  type Bounded_Queue (Size : Count_Type) is
+   --     record
+   --        Storage : Data_Array(0 .. Size-1);
+   --        Next_In : Index := 0;
+   --        Next_Out : Index := 0;
+   --        Num_Items : Count_Type := 0;
+   --     end record;
+
+   function Make (Capacity : Positive) return Bounded_Queue is
+      (Capacity - 1, (others => null), 0, 0, 0);
+
+   function Count(Q: in Bounded_Queue) return Count_Type is
+     (Q.Num_Items)
+     with Refined_Post => Count'Result = Q.Num_Items;
+
+   function Size (Q: in Bounded_Queue) return Count_Type is
+      (Q.Max_Index + 1);
+
+   -- Takes the next item off the queue.
+   procedure Next(Q: in out Bounded_Queue; Item : in out Data_Owner) is
+   begin
+      Move(Q.Storage(Q.Next_Out), Item);
+      Q.Next_Out := (Q.Next_Out + 1) mod (Q.Max_Index + 1);
+      Q.Num_Items := Q.Num_Items - 1;
+   end Next;
+
+   -- Adds an item to the queue.
+   procedure Put(Q: in out Bounded_Queue; Item : in out Data_Owner) is
+   begin
+      Move(Item, Q.Storage(Q.Next_In));
+      Q.Next_In := (Q.Next_In + 1) mod (Q.Max_Index + 1);
+      Q.Num_Items := Q.Num_Items + 1;
+   end Put;
+
+   function Valid(Q : Bounded_Queue) return Boolean
+   is (
+       Q.Next_In in Q.Storage'Range
+       and then Q.Next_Out in Q.Storage'Range
+       and then (Q.Storage(Q.Next_In) = null or Q.Num_Items = Q.Max_Index + 1)
+       and then (Q.Storage(Q.Next_Out) /= null or Q.Num_Items = 0)
+       and then Q.Max_Index < Natural'Last - 1
+      );
+
+end CubedOS.Lib.Bounded_Queues;

--- a/src/library/cubedos-lib-bounded_queues.ads
+++ b/src/library/cubedos-lib-bounded_queues.ads
@@ -1,0 +1,66 @@
+--------------------------------------------------------------------------------
+-- FILE   : cubedos-lib-bounded_queues.ads
+-- SUBJECT: SPARK verified bounded queue implementation.
+-- AUTHOR : (C) Copyright 2023 by Vermont Technical College
+--
+-- First in first out queue of a fixed size implemented in SPARK.
+--------------------------------------------------------------------------------
+pragma SPARK_Mode(On);
+
+generic
+   type Data is private;
+package CubedOS.Lib.Bounded_Queues is
+
+   subtype Count_Type is Natural;
+   type Data_Owner is access Data;
+
+   type Bounded_Queue (Max_Index : Natural) is private;
+
+   function Valid(Q : Bounded_Queue) return Boolean
+     with Ghost;
+
+   -- Creates a new queue.
+   function Make (Capacity : Positive) return Bounded_Queue
+     with Pre => Capacity < Natural'Last - 1,
+     Post => Valid(Make'Result);
+
+   -- Return the number of items currently in the queue.
+   function Count (Q: in Bounded_Queue) return Count_Type
+     with Pre => Valid(Q);
+
+   -- Return the total capacity of the queue
+   function Size (Q: in Bounded_Queue) return Count_Type
+     with Pre => Valid(Q);
+
+   -- Takes the next item off the queue.
+   procedure Next(Q: in out Bounded_Queue; Item : in out Data_Owner)
+     -- Mention Valid the first time so that Count can pass, the second time
+     -- to let spark now that Count(Q) > 0.
+     with Pre =>
+       Valid(Q)
+       and then Count(Q) > 0
+       and then Valid(Q)
+       and then Item = null,
+       Post => Item /= null and Valid(Q);
+
+   -- Adds an item to the queue.
+   procedure Put(Q: in out Bounded_Queue; Item : in out Data_Owner)
+     with Pre => Valid(Q)
+     and then Count(Q) < Q.Max_Index + 1
+     and then Item /= null,
+     Post => Item = null and Valid(Q);
+
+private
+   subtype Index is Natural;
+   type Data_Array is array (Natural range <>) of Data_Owner;
+
+   type Bounded_Queue (Max_Index : Natural) is
+      record
+         Storage : Data_Array(0 .. Max_Index);
+         Next_In : Index := 1;
+         Next_Out : Index := 1;
+         Num_Items : Count_Type := 0;
+      end record;
+   -- Not using a type invariant because SPARK doesn't support them in this situation
+
+end CubedOS.Lib.Bounded_Queues;


### PR DESCRIPTION
It's not fully proven, but has been tested. A simple fixed size queue with a circular buffer.

The queue uses pointers. It was necessary to build it using pointers instead of just a generic data type because of SPARK's pointer rules.