### PR TITLE
Change Ada version to 2022.

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -7,9 +7,10 @@ maintainers = ["Vermont Technical College <example@example.com>"]
 maintainers-logins = ["cubesatlab"]
 [[depends-on]]
 gnatprove = "^12.1.1"
+aunit = "^23.0.0"
 
 [build-switches]
 "*".style_checks = "No"
+"*".ada_version = "Ada2022"
 development.optimization = ["-gnata", "-gnatwa", "-g", "-gnatVa", "-fstack-check"]
-[[depends-on]]
-aunit = "^23.0.0"
+

--- a/config/cubedos_config.gpr
+++ b/config/cubedos_config.gpr
@@ -21,6 +21,7 @@ abstract project Cubedos_Config is
            ,"-gnatwa" -- Enable all warnings
            ,"-gnatw.X" -- Disable warnings for No_Exception_Propagation
            ,"-gnatVa" -- All validity checks
+           ,"-gnat2022" -- Ada 2022 Mode
           );
 
    type Build_Profile_Kind is ("release", "validation", "development");


### PR DESCRIPTION
Ada 2022 adds the "Non_Blocking" aspect which will remove many spark errors related to concurrency.