### PR TITLE
doc: Add way to build document with Podman/Docker

### DIFF
--- a/doc/.dockerignore
+++ b/doc/.dockerignore
@@ -1,0 +1,19 @@
+# Build artifacts
+*.aux
+*.bbl
+*.blg
+*.log
+*.out
+*.toc
+build.log
+
+# VS Code
+.vscode/
+
+# Temporary files
+*.tmp
+*.temp
+
+# Keep Figure PDFs but exclude generated document PDFs
+CubedOS.pdf
+main.pdf

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,0 +1,20 @@
+# Use TeXLive Docker image
+FROM registry.gitlab.com/islandoftex/images/texlive:latest
+
+# Set working directory
+WORKDIR /doc
+
+# Copy source files
+COPY . .
+
+# Build the documentation using pdflatex and bibtex
+RUN pdflatex CubedOS.tex && \
+    bibtex CubedOS && \
+    pdflatex CubedOS.tex && \
+    pdflatex CubedOS.tex
+
+# Create output directory and copy the generated PDF
+RUN mkdir -p /output && cp CubedOS.pdf /output/
+
+# Default command to copy output to mounted volume
+CMD ["sh", "-c", "cp CubedOS.pdf /output/ 2>/dev/null || echo 'PDF copied to /output/CubedOS.pdf'"]

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,38 @@
+# Makefile for building CubedOS documentation using Docker
+
+# Variables
+IMAGE_NAME := cubedos-doc
+OUTPUT_DIR := output
+PDF_NAME := CubedOS.pdf
+RUNTIME := podman # Change to 'docker' if you prefer Docker
+
+# Default target
+.PHONY: all
+all: $(OUTPUT_DIR)/$(PDF_NAME)
+
+# Build the PDF using Docker
+$(OUTPUT_DIR)/$(PDF_NAME): Dockerfile CubedOS.tex
+	@echo "Building CubedOS documentation..."
+	@mkdir -p $(OUTPUT_DIR)
+	$(RUNTIME) build -t $(IMAGE_NAME) .
+	$(RUNTIME) run --rm -v $(PWD)/$(OUTPUT_DIR):/output $(IMAGE_NAME)
+	@echo "Documentation built successfully: $(OUTPUT_DIR)/$(PDF_NAME)"
+
+# Clean target
+.PHONY: clean
+clean:
+	@echo "Cleaning output directory..."
+	rm -rf $(OUTPUT_DIR)
+
+# Force rebuild
+.PHONY: rebuild
+rebuild: clean all
+
+# Help target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  all     - Build CubedOS.pdf (default)"
+	@echo "  clean   - Remove output directory"
+	@echo "  rebuild - Clean and rebuild"
+	@echo "  help    - Show this help message"

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,15 +5,43 @@ README
 This folder contains the official documentation set for CubedOS. The master document is
 CubedOS.tex. That document includes, directly or indirectly, all the other document components.
 
-To build the documentation, first be sure you have a LaTeX system installed. The precise way to
+Building the Documentation
+--------------------------
+
+### Docker/Podman Method (Recommended)
+
+The easiest way to build the documentation is using the provided Makefile and Docker image:
+
+```bash
+make
+```
+
+This will build the PDF using a containerized LaTeX environment and place the result in `output/CubedOS.pdf`. No local LaTeX installation is required.
+
+Additional make targets:
+- `make clean` - Remove the output directory
+- `make rebuild` - Clean and rebuild from scratch
+- `make help` - Show available targets
+
+By default, the Makefile uses Podman. To use Docker instead, edit the `RUNTIME` variable in the Makefile or run:
+
+```bash
+make RUNTIME=docker
+```
+
+### Manual LaTeX Method
+
+If you prefer to build locally, first ensure you have a LaTeX system installed. The precise way to
 do this depends on your system and is outside the scope of this document. Then, issue the
 following commands:
 
-    > pdflatex CubedOS
-    > bibtex CubedOS
-    > pdflatex CubedOS
-    > pdflatex CubedOS
-    
+```bash
+pdflatex CubedOS
+bibtex CubedOS
+pdflatex CubedOS
+pdflatex CubedOS
+```
+
 It is necessary to run the `pdflatex` command multiple times to ensure that all cross references
 are resolved properly. The resulting documentation will be in `CubedOS.pdf`.
 


### PR DESCRIPTION
This pull request introduces a new Docker-based workflow for building the CubedOS documentation, making the build process more reproducible and easier to run across different environments. It adds a `Dockerfile` for containerized LaTeX builds, a corresponding `Makefile` to automate the process, and updates `.dockerignore` to exclude unnecessary files from the build context.

**Docker-based documentation build:**

* Added `doc/Dockerfile` to build the CubedOS PDF documentation using TeXLive in a container, automating LaTeX and BibTeX runs and exporting `CubedOS.pdf` to an output directory.
* Added `doc/Makefile` to simplify building, cleaning, and rebuilding documentation via Docker or Podman, including helpful targets and usage instructions.

**Build context and artifacts management:**

* Updated `doc/.dockerignore` to exclude LaTeX build artifacts, temporary files, VS Code settings, and generated document PDFs (except for figure PDFs), reducing unnecessary files in the Docker build context.